### PR TITLE
Fix menu sorting.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,7 +31,8 @@ editURL = "https://github.com/NuevoFoundation/workshops/tree/master/content/"
 showVisitedLinks = true # default is false
 themeStyle = "flex" # "original" or "flex" # default "flex"
 themeVariant = "" # choose theme variant "green", "gold" , "gray", "blue" (default)
-ordersectionsby = "weight" # ordersectionsby = "title"
+orderSectionsBy = "title"
+orderPagesBy = "weight"
 disableHomeIcon = true # default is false
 disableSearch = false # default is false
 disableNavChevron = false # set true to hide next/prev chevron, default is false

--- a/content/english/adafruit/_index.md
+++ b/content/english/adafruit/_index.md
@@ -7,7 +7,6 @@ difficulty: "Beginner"
 download: ""
 draft: false
 icon: "fas fa-microchip"
-weight: 1
 translationKey: "adafruit-main"
 ---
 

--- a/content/english/adventure/_index.md
+++ b/content/english/adventure/_index.md
@@ -7,7 +7,6 @@ prereq: "Python Basics - Writing to Console (Print), Reading from Console, Strin
 download: ""
 draft: false
 icon: "fab fa-python"
-weight: 11
 ---
 
 # Part 1 – Welcome!

--- a/content/english/csharp-guess-the-word/_index.md
+++ b/content/english/csharp-guess-the-word/_index.md
@@ -7,7 +7,6 @@ difficulty: "Intermediate"
 download: ""
 draft: false
 icon: "fas fa-code"
-weight: 3
 ---
 
 # Welcome

--- a/content/english/image-manipulation/_index.md
+++ b/content/english/image-manipulation/_index.md
@@ -1,11 +1,10 @@
 ---
 title: "Python: Image Manipulation"
-description: "An introduction to manipulating images in python."
+description: "An introduction to manipulating images in Python"
 date: 2020-02-10T13:24:17-07:00
 difficulty: "Beginner"
 draft: false
 icon: "fab fa-python"
-weight: 15
 ---
 
 # Introduction

--- a/content/english/jsappybird/index_1.md
+++ b/content/english/jsappybird/index_1.md
@@ -5,7 +5,6 @@ date: 2019-07-23T10:42:43-07:00
 difficulty: "Beginner/Intermediate"
 draft: true
 hidden: true
-weight: 5
 ---
 
 ![alt text](resources/_gen/images/flappy.png "JSappyBird")

--- a/content/english/microbit/_index.md
+++ b/content/english/microbit/_index.md
@@ -1,12 +1,11 @@
 ---
-title: "Microbit: Coding with mini computers"
-description: "Using MicroBits to teach students about JavaScript and hardware"
+title: "MicroBit: Coding with mini computers"
+description: "Using MicroBits to learn about JavaScript and hardware"
 date: 2019-07-23T14:54:53-07:00
 difficulty: "Beginner to Intermediate"
 download: "https://github.com/NuevoFoundation/workshops/tree/master/content/microbit"
 draft: false
 icon: "fas fa-microchip"
-weight: 6
 ---
 
 ### An introduction to JavaScript and hardware using [MicroBits](https://microbit.org/guide/)

--- a/content/english/python-basics/_index.md
+++ b/content/english/python-basics/_index.md
@@ -1,12 +1,11 @@
 ---
 title: "Python: Basics"
-description: "Basics of python"
+description: "Learn basic concepts of using the Python programming language"
 date: 2019-07-30T18:45:38-07:00
 prereq: "none"
 difficulty: "Beginner"
 icon: "fab fa-python"
 draft: false
-weight: 10
 ---
 
 # Python basics

--- a/content/english/python-earsketch/_index.md
+++ b/content/english/python-earsketch/_index.md
@@ -1,13 +1,12 @@
 ---
 title: "Python: Create music with EarSketch"
-description: "Create music using EarSketch"
+description: "Create music using Python and EarSketch"
 date: 2019-07-23T11:45:38-07:00
 prereq: "Python Basics: Print, Comments, Functions"
 difficulty: "Intermediate"
 download: ""
 draft: false
 icon: "fab fa-python"
-weight: 12
 ---
 <iframe width="100%" height="600px" src="https://www.youtube.com/embed/g0u1CkbpUWQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/english/python-turtle/_index.md
+++ b/content/english/python-turtle/_index.md
@@ -1,13 +1,12 @@
 ---
-title: "Python: Coding with Turtles"
-description: "Learning Python with Turtle"
+title: "Python: Coding with Turtle"
+description: "Learn how to draw on a canvas with Python with Turtle"
 date: 2019-07-25T13:24:17-07:00
 prereq: "Python Basics"
 difficulty: "Beginner"
 image: ""
 draft: false
 icon: "fab fa-python"
-weight: 13
 translationKey: "python-turtle-home"
 ---
 

--- a/content/english/web-basics/_index.md
+++ b/content/english/web-basics/_index.md
@@ -1,12 +1,10 @@
 ---
 title: "HTML & CSS: Web Basics"
-description: "An introductory guide on how to make a simple website from scratch."
+description: "An introductory guide on how to make a simple website from scratch"
 date: 2019-09-03T17:53:41-07:00
 draft: false
 difficulty: "Beginner"
 icon: "fab fa-html5"
-weight: 4
-
 ---
 
 # Let's build a website!

--- a/content/espanol/adafruit/_index.md
+++ b/content/espanol/adafruit/_index.md
@@ -6,7 +6,6 @@ prereq: "Ninguno"
 difficulty: "Principiante"
 download: ""
 draft: false
-weight: 1
 translationKey: "adafruit-main"
 ---
 

--- a/content/espanol/python-turtle/_index.md
+++ b/content/espanol/python-turtle/_index.md
@@ -4,7 +4,6 @@ description: "Aprender Python con Turtle"
 date: 2019-09-22T23:26:18-05:00
 prereq: "Ninguno"
 difficulty: "Principiante"
-weight: 2
 translationKey: "python-turtle-home"
 ---
 

--- a/themes/docdock/exampleSite/config.toml
+++ b/themes/docdock/exampleSite/config.toml
@@ -32,7 +32,8 @@ editURL = "https://github.com/vjeantet/hugo-theme-docdock/edit/master/exampleSit
 showVisitedLinks = true # default is false
 themeStyle = "flex" # "original" or "flex" # default "flex"
 themeVariant = "" # choose theme variant "green", "gold" , "gray", "blue" (default)
-ordersectionsby = "weight" # ordersectionsby = "title"
+orderSectionsBy = "title"
+orderPagesBy = "weight"
 disableHomeIcon = false # default is false
 disableSearch = false # default is false
 disableNavChevron = false # set true to hide next/prev chevron, default is false

--- a/themes/docdock/exampleSite/content/content-organisation/_index.md
+++ b/themes/docdock/exampleSite/content/content-organisation/_index.md
@@ -99,7 +99,7 @@ in your frontmatter add `weight` param with a number to order.
 	weight = 4
 	+++
 
-{{%info%}}add `ordersectionsby = "title"` in your config.toml to order menu entries by title{{%/info%}}
+{{%info%}}add `orderSectionsBy = "title"` in your config.toml to order menu entries by title{{%/info%}}
 
 
 ### Hide a menu entry

--- a/themes/docdock/layouts/partials/flex/selectnavigation.html
+++ b/themes/docdock/layouts/partials/flex/selectnavigation.html
@@ -1,5 +1,5 @@
 {{- $currentNode := . }}
-{{- if eq .Site.Params.ordersectionsby "title"}}
+{{- if eq .Site.Params.orderSectionsBy "title"}}
 {{- range .Site.Home.Sections.ByTitle}}
 {{- template "menu-nav" dict "sect" . "currentnode" $currentNode "level" 1}}
 {{- end}}
@@ -31,7 +31,7 @@
 {{- end}}
 {{- $pages := (.Scratch.Get "pages") }}
 
-{{- if eq .Site.Params.ordersectionsby "title"}}
+{{- if eq .Site.Params.orderPagesBy "title"}}
 {{- range $pages.ByTitle }}
 {{- if and .Params.hidden (not $.showhidden) }}
 {{- else}}

--- a/themes/docdock/layouts/partials/menu.html
+++ b/themes/docdock/layouts/partials/menu.html
@@ -1,7 +1,7 @@
 {{- $currentNode := . }}
 {{- $showvisitedlinks := .Site.Params.showVisitedLinks -}}
 
-{{- if eq .Site.Params.ordersectionsby "title"}}
+{{- if eq .Site.Params.orderSectionsBy "title"}}
   {{- range .Site.Home.Sections.ByTitle}}
   {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
   {{- end}}
@@ -46,7 +46,7 @@
           {{- end}}
           {{- $pages := (.Scratch.Get "pages") }}
 
-        {{- if eq .Site.Params.ordersectionsby "title"}}
+        {{- if eq .Site.Params.orderPagesBy "title"}}
           {{- range $pages.ByTitle }}
             {{- if and .Params.hidden (not $.showhidden) }}
             {{- else}}


### PR DESCRIPTION
Now the workshops in the left menu are forced to be sorted by
title, removing the need for us to manually sort the workshops
alphabetically. Removed the weight configuration for index pages
as a result.

Subpages within a workshop will still require a weight configuration
to work properly.