### PR TITLE
Limit content width to 900px

### DIFF
--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -302,6 +302,7 @@ article section.page {
   margin: 0 1rem 0 20rem;
   overflow-y: auto;
   padding: 2rem 4rem;
+  max-width: 900px;
 }
 article section.page h1:first-of-type {
   margin: 3rem 0rem;


### PR DESCRIPTION
Large enough that Repl.it will still look fine in it. Small enough that people won't have to read extremely long lines.

-------
# 15" Laptop screen

## Before:
![image](https://user-images.githubusercontent.com/1588988/131772052-0773a739-d046-44aa-886a-2a8dd81ceac4.png)

## After:
![image](https://user-images.githubusercontent.com/1588988/131772008-5b30241e-659e-46d0-8955-844be74a604e.png)

------

# Huge screen (Simulated by using 67% zoom)

## Before:
![image](https://user-images.githubusercontent.com/1588988/131772137-a9d0ca4d-afc3-458b-81a6-8df797297c2f.png)

## After:
![image](https://user-images.githubusercontent.com/1588988/131772194-afa26bde-907f-4c29-b9ee-2ca5a05ed694.png)
