### PR TITLE
No cross-workshop next/prev buttons

### DIFF
--- a/themes/docdock/layouts/partials/next-prev-page.html
+++ b/themes/docdock/layouts/partials/next-prev-page.html
@@ -4,6 +4,11 @@
 
 {{- template "menu-nextprev" dict "menu" .Site.Home "currentnode" $currentNode -}}
 
+<!--
+    This logic recursively traverses the page tree (pre-order traversal, in ascending order of each page's weight property within a given level)
+    During this iteration, the "menu" property changes to be the item in the iteration, whereas "currentNode" is fixed and
+    represents the current page, where the next and previous buttons will be placed.
+ -->
 {{- define "menu-nextprev" -}}
     {{- $currentNode := .currentnode -}}
     {{- if ne .menu.Params.hidden true -}}
@@ -17,28 +22,34 @@
             {{- end -}}
         {{- end -}}
         {{- $currentNode.Scratch.Set "prevPageTmp" .menu -}}
+        {{- $currentNode.Scratch.Set "pages" .menu.Pages -}}
+        {{- if .menu.IsHome -}}
+            {{- $currentNode.Scratch.Set "pages" .menu.Sections -}}
+        {{- else if .menu.Sections -}}
+            {{- $currentNode.Scratch.Set "pages" (.menu.Pages | union .menu.Sections) -}}
+        {{- end -}}
+        {{- $pages := ($currentNode.Scratch.Get "pages") -}}
 
-            {{- $currentNode.Scratch.Set "pages" .menu.Pages -}}
-            {{- if .menu.IsHome -}}
-                {{- $currentNode.Scratch.Set "pages" .menu.Sections -}}
-            {{- else if .menu.Sections -}}
-                {{- $currentNode.Scratch.Set "pages" (.menu.Pages | union .menu.Sections) -}}
-            {{- end -}}
-            {{- $pages := ($currentNode.Scratch.Get "pages") -}}
-
-            {{- range $pages.ByWeight -}}
-                {{- template "menu-nextprev" dict "menu" . "currentnode" $currentNode -}}
-            {{- end -}}
+        {{- range $pages.ByWeight -}}
+            {{- template "menu-nextprev" dict "menu" . "currentnode" $currentNode -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 
     
 {{- if not $.Site.Params.disableNavChevron -}}
-    {{- with ($.Scratch.Get "prevPage") -}}
-        <a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i><label>{{.Title}}</label></a>
-    {{ end -}}
-    {{- with ($.Scratch.Get "nextPage") -}}
-        <a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><label>{{.Title}}</label><i class="fa fa-chevron-right"></i></a>
-    {{- end }}
+    {{ $isFirstPageOfWorkshop := (ne .Section ($.Scratch.Get "prevPage").Section) }}
+    {{ $isLastPageOfWorkshop := (ne .Section ($.Scratch.Get "nextPage").Section) }}
+
+    {{- if (not $isFirstPageOfWorkshop) -}}
+        {{- with ($.Scratch.Get "prevPage") -}}
+            <a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i><label>{{.Title}}</label></a>
+        {{- end -}}
+    {{- end -}}
+    {{- if (not $isLastPageOfWorkshop) -}}
+        {{- with ($.Scratch.Get "nextPage") -}}
+            <a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><label>{{.Title}}</label><i class="fa fa-chevron-right"></i></a>
+        {{- end -}}
+    {{- end -}}
 {{- end -}}
 </div>


### PR DESCRIPTION
- Adds variables $isFirstPageOfWorkshop and $isLastPageOfWorkshop that detect if it's the first or last page of the current workshop
- If we're in the first page of the workshop, don't show the left arrow to go to the previous page
- If we're in the last page of the workshop, don't show the right arrow to go to the next page

I've also fixed the indentation of the code in the same page and added a comment explaining that logic from the same file

## Before
| First page | Last page |
|---|---|
| ![image](https://user-images.githubusercontent.com/1588988/141414981-18f17a38-c845-4970-8f06-a7dc2a5f7945.png) | ![image](https://user-images.githubusercontent.com/1588988/141415084-b986242e-8f0f-47dc-b92e-c1e99c52e9f6.png) |

## After
| First page | Last page |
|---|---|
|  ![image](https://user-images.githubusercontent.com/1588988/141414702-e55c6bb9-934c-437d-8cc0-fd097547107e.png) | ![image](https://user-images.githubusercontent.com/1588988/141414747-eb5ce88a-635a-483e-a0fa-46bf9f7bbd34.png) |
