### PR TITLE
Scope sidebar navigation to current workshop

### DIFF
--- a/themes/docdock/layouts/partials/flex/selectnavigation.html
+++ b/themes/docdock/layouts/partials/flex/selectnavigation.html
@@ -1,12 +1,17 @@
 {{- $currentNode := . }}
+
 {{- if eq .Site.Params.orderSectionsBy "title"}}
-{{- range .Site.Home.Sections.ByTitle}}
-{{- template "menu-nav" dict "sect" . "currentnode" $currentNode "level" 1}}
-{{- end}}
+  {{- range .Site.Home.Sections.ByTitle}}
+    {{- if (or (eq $currentNode .Site.Home) (.IsAncestor $currentNode))}}
+      {{- template "menu-nav" dict "sect" . "currentnode" $currentNode "level" 1}}
+    {{- end}}
+  {{- end}}
 {{- else}}
-{{- range .Site.Home.Sections.ByWeight}}
-{{- template "menu-nav" dict "sect" . "currentnode" $currentNode "level" 1}}
-{{- end}}
+  {{- range .Site.Home.Sections.ByWeight}}
+    {{- if (or (eq $currentNode .Site.Home) (.IsAncestor $currentNode))}}
+      {{- template "menu-nav" dict "sect" . "currentnode" $currentNode "level" 1}}
+    {{- end}}
+  {{- end}}
 {{- end}}
 
 <!-- templates -->

--- a/themes/docdock/layouts/partials/menu.html
+++ b/themes/docdock/layouts/partials/menu.html
@@ -3,11 +3,15 @@
 
 {{- if eq .Site.Params.orderSectionsBy "title"}}
   {{- range .Site.Home.Sections.ByTitle}}
-  {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+    {{- if (or (eq $currentNode .Site.Home) (.IsAncestor $currentNode))}}
+      {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+    {{- end}}
   {{- end}}
 {{- else}}
   {{- range .Site.Home.Sections.ByWeight}}
-  {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+    {{- if (or (eq $currentNode .Site.Home) (.IsAncestor $currentNode))}}
+      {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+    {{- end}}
   {{- end}}
 {{- end}}
 


### PR DESCRIPTION
Closes #253 

Note that this only affects the sidebar when inside of a workshop. The sidebar is unaffected in the homepage.

Before:
![image](https://user-images.githubusercontent.com/1588988/144772918-8858b219-1399-401e-bc6d-fdb4ac1e6372.png)

After:
![image](https://user-images.githubusercontent.com/1588988/144772967-3b7f9869-a606-4c2d-bc45-8c3e2ca3b195.png)