### PR TITLE
Temporarily revert maximum content width until #259 is fixed

### DIFF
--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -294,7 +294,8 @@ article {
   margin-right: auto;
   margin-left: auto;
   width:100%;
-  max-width: 1210px;
+  /* Re-enable max-width after #259 is fixed (https://github.com/NuevoFoundation/workshops/issues/259) */
+  /* max-width: 1210px; */
 }
 
 article section.page {


### PR DESCRIPTION
Removing the maximum content width until #259 is fixed, as a mitigation so that the SQL workshop works as expected