### PR TITLE
UI/UX changes in line with spec: back button from workshop modules to…

### DIFF
--- a/themes/docdock/i18n/en.toml
+++ b/themes/docdock/i18n/en.toml
@@ -82,3 +82,7 @@ other = "Hint"
 
 [type]
 other = "Workshop type:"
+
+# menu.html
+[workshop-dashboard]
+"Workshop Dashboard"

--- a/themes/docdock/i18n/en.toml
+++ b/themes/docdock/i18n/en.toml
@@ -85,4 +85,4 @@ other = "Workshop type:"
 
 # menu.html
 [workshop-dashboard]
-"Workshop Dashboard"
+other = "Workshop Dashboard"

--- a/themes/docdock/layouts/_default/single.html
+++ b/themes/docdock/layouts/_default/single.html
@@ -1,5 +1,3 @@
 {{ define "main" }}
-    <div class="main-content">
-        {{ .Content }}
-    </div>
+    {{ .Content }}
 {{ end }}

--- a/themes/docdock/layouts/_default/single.html
+++ b/themes/docdock/layouts/_default/single.html
@@ -1,3 +1,5 @@
 {{ define "main" }}
-    {{ .Content }}
+    <div class="main-content">
+        {{ .Content }}
+    </div>
 {{ end }}

--- a/themes/docdock/layouts/partials/menu.html
+++ b/themes/docdock/layouts/partials/menu.html
@@ -6,7 +6,7 @@
   <li class="dd-item back-to-dashboard">
     <div class="menu-item">
       <span>
-        Workshop Dashboard
+        {{ i18n "workshop-dashboard" }}
       </span>
       <a href="{{ "/" | relLangURL }}" aria-label="Back to workshops dashboard" class="back-nav-link">
         <i class="fa fa-angle-left fa-lg category-icon back-nav-icon"></i>

--- a/themes/docdock/layouts/partials/menu.html
+++ b/themes/docdock/layouts/partials/menu.html
@@ -1,5 +1,21 @@
 {{- $currentNode := . }}
 {{- $showvisitedlinks := .Site.Params.showVisitedLinks -}}
+
+{{/* Add back to workshops dashboard navigation if not on home page */}}
+{{- if not .IsHome -}}
+  <li class="dd-item back-to-dashboard">
+    <div class="menu-item">
+      <span>
+        Workshop Dashboard
+      </span>
+      <a href="{{ "/" | relLangURL }}" aria-label="Back to workshops dashboard" class="back-nav-link">
+        <i class="fa fa-angle-left fa-lg category-icon back-nav-icon"></i>
+      </a>
+    </div>
+    <hr class="back-nav-separator">
+  </li>
+{{- end -}}
+
 {{- if eq .Site.Params.orderSectionsBy "title"}}
   {{- range .Site.Home.Sections.ByTitle}}
     {{- if (or (eq $currentNode .Site.Home) (.IsAncestor $currentNode))}}

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -1,5 +1,16 @@
 jQuery(document).ready(function () {
   jQuery(".category-icon").on("click", function () {
+    // Check if this is the back navigation icon
+    if ($(this).hasClass("back-nav-icon")) {
+      console.log("Back navigation clicked");
+      console.log("Navigating to:", $(this).parent().attr("href"));
+      console.log("Current page:", window.location.href);
+      // Allow the default link behavior for back navigation
+      window.location.href = $(this).parent().attr("href");
+      return true;
+    }
+    
+    // Original dropdown behavior for other category icons
     $(this).toggleClass("fa-angle-down fa-angle-up");
     $(this).parent().parent().children("ul").toggle();
     return false;

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -2,10 +2,6 @@ jQuery(document).ready(function () {
   jQuery(".category-icon").on("click", function () {
     // Check if this is the back navigation icon
     if ($(this).hasClass("back-nav-icon")) {
-      console.log("Back navigation clicked");
-      console.log("Navigating to:", $(this).parent().attr("href"));
-      console.log("Current page:", window.location.href);
-      // Allow the default link behavior for back navigation
       window.location.href = $(this).parent().attr("href");
       return true;
     }

--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -182,6 +182,81 @@ article > aside .menu .dd-item div i.category-icon:hover {
 article > aside .menu .dd-item li {
   border-left: 1px solid #eee;
 }
+
+/* Back to workshops dashboard navigation styles */
+article > aside .menu .dd-item.back-to-dashboard {
+  margin: 0.5rem 0px 0.5rem 20px;
+  padding-left: 1rem;
+  list-style: none;
+  font-size: 14px;
+}
+
+article > aside .menu .dd-item.back-to-dashboard .menu-item {
+  margin-left: -20px;
+}
+
+article > aside .menu .dd-item.back-to-dashboard div {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+}
+
+article > aside .menu .dd-item.back-to-dashboard div * {
+  line-height: inherit;
+}
+
+article > aside .menu .dd-item.back-to-dashboard div a {
+  display: flex !important;
+  align-items: start !important;
+  justify-content: center !important;
+  order: 1 !important;
+  width: 20px !important;
+  cursor: pointer;
+  text-decoration: none;
+  color: black;
+  padding: 0 !important;
+  flex-shrink: 0 !important;
+  flex-grow: 0 !important;
+  flex-basis: 20px !important;
+}
+
+article > aside .menu .dd-item.back-to-dashboard div a i.category-icon {
+  display: flex;
+  align-items: start;
+  justify-content: center;
+}
+
+article > aside .menu .dd-item.back-to-dashboard div span {
+  display: flex !important;
+  order: 2 !important;
+  padding: 0 0rem 0 0.5rem !important;
+  color: black;
+  font-size: 14px;
+  font-weight: bold;
+  flex-shrink: 1 !important;
+  flex-grow: 0 !important;
+  flex-basis: auto !important;
+  min-width: 0 !important;
+  width: auto !important;
+  max-width: none !important;
+}
+
+article > aside .menu .dd-item.back-to-dashboard div a:hover,
+article > aside .menu .dd-item.back-to-dashboard div a:focus,
+article > aside .menu .dd-item.back-to-dashboard div a:active {
+  background-color: #eee;
+  border-radius: 0.2rem;
+  padding: 0 0rem;
+}
+
+article > aside .menu .dd-item.back-to-dashboard .back-nav-separator {
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 0.25rem 5px 0.75rem 5px;
+  width: auto;
+}
+
 article > aside section {
   margin: 2rem 0rem;
 }
@@ -488,10 +563,69 @@ button, input, optgroup, select, textarea {
 .panel.panel-primary {
   border: 4px solid black;
 }
+
+/* Right-align panel-primary on workshop first pages */
+article section.page .panel.panel-primary {
+  position: relative;
+  float: right;
+  clear: right;
+  max-width: 350px;
+  width: 350px;
+  margin: 8rem 10rem 1.5rem 3rem; /* top right bottom left - adds 6rem space from right edge */
+  transform: translateX(-2rem); /* Moves it 2rem more towards center */
+}
+
+/* Ensure text flows around the right-floated panels */
+article section.page .panel.panel-primary + * {
+  clear: none; /* Allow text to wrap around panels */
+}
+
+/* For mobile devices - stack panels below content */
+@media (max-width: 768px) {
+  article section.page .panel.panel-primary {
+    position: static;
+    float: none;
+    clear: both;
+    width: 100%;
+    max-width: none;
+    margin: 1rem 0;
+    transform: none;
+  }
+}
 .panel-primary > .panel-heading {
   background-color: #000000 !important;
   border-radius: 0px;
 }
+
+/* Thick black bar before table of contents header */
+article section.page h2#table-of-contents::before {
+  content: "";
+  position: absolute;
+  transform: translateY(-3rem); /* Move bar above the h2 */
+  width: 33.33%; /* Takes roughly a third of horizontal space */
+  height: 8px; /* Thick black bar */
+  background-color: #000000;
+  margin-bottom: 2rem; /* Space below the bar */
+}
+
+/* Ensure the h2 has relative positioning for the absolute bar */
+article section.page h2#table-of-contents {
+  position: relative;
+  margin-top: 5rem; /* Extra space to accommodate the bar above */
+}
+
+/* Hide the bar on mobile for better spacing */
+@media (max-width: 768px) {
+  article section.page h2#table-of-contents::before {
+    width: 50%; /* Slightly wider on mobile */
+    transform: translateY(-2rem); /* Less space on mobile */
+  }
+  
+  article section.page h2#table-of-contents {
+    margin-top: 4rem; /* Less margin on mobile */
+  }
+}
+
 article section.page h1 {
   margin-top: 4rem;
 }
@@ -500,7 +634,6 @@ article section.page h2 {
   display: flex;
   flex-wrap: wrap;
   height: 77;
-  top: 27px;
   left: 24;
   color:#000000;
   font-family: "Space Mono", "Lato", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;


### PR DESCRIPTION
Some changes to the UI/UX to be more aligned with the Figma prototype:

1. back navigation from specific workshop to workshop dashboard
2. Right-alignment of primary panel on workshop landing pages
3. Black bar under body text of workshop landing page

Implementations should also be able to work with mobile devices as well, but this requires more testing. Code is a bit messy; sorry about that!!!