### PR TITLE
Add Google Analytics 4 (GA4) to workshops site

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -1,0 +1,28 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-879TB3F3ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-879TB3F3ES');
+</script>
+
+<meta
+  name="description"
+  content="
+{{ with.Description }}
+    {{ . }}
+{{ else }}
+    {{ with.Site.Params.description }}
+        {{ . }}
+    {{ end }}
+{{ end }}"
+/>
+{{ with.Site.Params.author }}
+<meta
+  name="author"
+  content="
+    {{ . }}"
+/>
+{{ end }}


### PR DESCRIPTION
Add GA4 tracking with measurement ID G-879TB3F3ES by overriding the Hugo theme's custom-head.html partial. This adds the gtag.js script to every page on workshops.nuevofoundation.org automatically.

Replaces the old Universal Analytics (UA) approach from the theme's example site with the current GA4 standard.

Closes #3