### PR TITLE
Fix duplicate `hidden` YAML key in security-phishing answer keys (es, pt-BR, ko)

### DIFF
--- a/content/brazilian-portuguese/security-phishing/answer-key.md
+++ b/content/brazilian-portuguese/security-phishing/answer-key.md
@@ -3,7 +3,6 @@ title: "Gabarito - Segurança"
 description: "Gabarito de referência fácil para o currículo de segurança"
 draft: false
 hidden: true
-hidden: true
 weight: 5
 ---
 

--- a/content/espanol/security-phishing/answer-key.md
+++ b/content/espanol/security-phishing/answer-key.md
@@ -3,7 +3,6 @@ title: "Answer Key - Security"
 description: "Respuestas para el curriculo de seguridad"
 draft: false
 hidden: true
-hidden: true
 weight: 5
 ---
 

--- a/content/korean/security-phishing/answer-key.md
+++ b/content/korean/security-phishing/answer-key.md
@@ -3,7 +3,6 @@ title: "정답"
 description: "Easy reference answer key for the security curriculum"
 draft: false
 hidden: true
-hidden: true
 weight: 5
 ---
 


### PR DESCRIPTION
## Summary

Removes a duplicate `hidden: true` key from the YAML frontmatter of the `security-phishing/answer-key.md` page in three language versions:

- `content/espanol/security-phishing/answer-key.md`
- `content/brazilian-portuguese/security-phishing/answer-key.md`
- `content/korean/security-phishing/answer-key.md`

## Problem

Running `hugo` fails to build the site: