### PR TITLE
Add GitHub-style inline code highlighting

### DIFF
--- a/themes/docdock/static/css/nucleus.css
+++ b/themes/docdock/static/css/nucleus.css
@@ -681,6 +681,19 @@ pre {
 
 code {
   vertical-align: bottom;
+  font-weight: 700;
+  border-radius: 3px;
+  background-color: rgba(27, 31, 35, 0.05);
+  padding: 0.2em 0.4em;
+  line-height: 1.6;
+  font-size: 0.925em;
+}
+
+pre code {
+  font-weight: normal;
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
 }
 
 small {


### PR DESCRIPTION
Replaces minimal `code` styling with GitHub-style: semi-bold text, light gray background, rounded corners. Code blocks (`pre code`) keep their existing style via explicit reset.

Closes #43