### PR TITLE
Use CSS Grid for homepage workshop buttons

### DIFF
--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -1049,13 +1049,9 @@ div.notices.help {
 }
 
 ul.children.children-card {
-  flex-wrap: wrap;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1.2rem;
 }
 ul.children.children-card > .workshop-button {
   position: relative;
@@ -1063,14 +1059,9 @@ ul.children.children-card > .workshop-button {
   cursor: pointer;
   text-align: left;
   white-space: normal;
-  -webkit-box-flex: 1;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
-  width: 20%;
-  min-width: 250px;
-  margin: 1.2rem 1.2rem;
+  margin: 0;
   padding: 1.5rem 1.5rem 2rem 1.5rem;
   border: 0.3rem solid #000;
   border-radius: 5px;


### PR DESCRIPTION
Replaces flexbox with CSS Grid (`auto-fill, minmax(250px, 1fr)`) so the last row of workshop cards no longer stretches when there are fewer items.

Closes #290