### PR TITLE
Move jQuery to CDN with local fallback

### DIFF
--- a/themes/docdock/layouts/partials/flex/head.html
+++ b/themes/docdock/layouts/partials/flex/head.html
@@ -46,7 +46,8 @@
 <link type="text/css" rel="stylesheet" href="{{"css/nuevoweb.css" | relURL }}" />
 <link rel="stylesheet" href="{{"css/chunk.css" | relURL}}" />
 <link rel="stylesheet" href="{{"css/data-style.css" | relURL}}" />
-<script src="{{"js/jquery-3.6.4.min.js" | relURL}}"></script>
+<script src="https://code.jquery.com/jquery-3.6.4.min.js" integrity="sha256-oP6HI9z1XaZNBrJURtCoUT5SUnxFr8s3BzRl+cbzUq8=" crossorigin="anonymous"></script>
+<script>window.jQuery || document.write('<script src="{{"js/jquery-3.6.4.min.js" | relURL}}"><\/script>')</script>
 <!-- Both polyfill and tex packages (next 2 lines) required for MathJax -->
 <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
Loads jquery-3.6.4 from `code.jquery.com` with SRI integrity hash. Includes `document.write` local fallback for school environments with restricted firewalls.

Closes #42