### PR TITLE
Move featherlight to CDN with SRI hashes

### DIFF
--- a/themes/docdock/layouts/partials/flex/scripts.html
+++ b/themes/docdock/layouts/partials/flex/scripts.html
@@ -1,7 +1,7 @@
 <script src="{{"js/clipboard.min.js" | relURL}}"></script>
 
-<link href="{{"css/featherlight.min.css" | relURL}}" rel="stylesheet">
-<script src="{{"js/featherlight.min.js" | relURL}}"></script>
+<link href="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.css" rel="stylesheet" integrity="sha256-UHP0vaPqS1SY6G5ySZndoVKzQJYBSVF2pqs4mPrDEcE=" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.js" integrity="sha256-n/xqYYgRqwjNP/0+0VT5jmenhdqhKCSkSpmFT5aPGZM=" crossorigin="anonymous"></script>
 
 {{if eq .Site.Params.highlightClientSide true}}
 <script src="{{"js/highlight.pack.js" | relURL}}"></script>

--- a/themes/docdock/layouts/partials/flex/scripts.html
+++ b/themes/docdock/layouts/partials/flex/scripts.html
@@ -1,7 +1,7 @@
 <script src="{{"js/clipboard.min.js" | relURL}}"></script>
 
-<link href="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.css" rel="stylesheet" integrity="sha256-UHP0vaPqS1SY6G5ySZndoVKzQJYBSVF2pqs4mPrDEcE=" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.js" integrity="sha256-n/xqYYgRqwjNP/0+0VT5jmenhdqhKCSkSpmFT5aPGZM=" crossorigin="anonymous"></script>
+<link href="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.css" rel="stylesheet" integrity="sha256-UHP0vaPqS1SY6G5ySZndoVKzQJYBSVF2pqs4mPrDEcE=" crossorigin="anonymous" onerror="this.onerror=null;this.href='{{"css/featherlight.min.css" | relURL}}';">
+<script src="https://cdn.jsdelivr.net/npm/featherlight@1.7.14/release/featherlight.min.js" integrity="sha256-n/xqYYgRqwjNP/0+0VT5jmenhdqhKCSkSpmFT5aPGZM=" crossorigin="anonymous" onerror="this.onerror=null;this.src='{{"js/featherlight.min.js" | relURL}}';"></script>
 
 {{if eq .Site.Params.highlightClientSide true}}
 <script src="{{"js/highlight.pack.js" | relURL}}"></script>


### PR DESCRIPTION
Loads featherlight 1.7.14 CSS and JS from `jsdelivr` CDN with SRI integrity hashes and `crossorigin=anonymous` for security.

Closes #46