### PR TITLE
Fix screenreader navigation with keyboard-accessible expand/collapse buttons

### DIFF
--- a/themes/docdock/layouts/partials/flex/body-beforecontent.html
+++ b/themes/docdock/layouts/partials/flex/body-beforecontent.html
@@ -17,16 +17,18 @@
 
 <article>
   <aside>
+    <nav aria-label="Workshop navigation">
     <ul class="menu">
       {{- if not .Site.Params.disableHomeIcon}}
       <li data-nav-id="{{"/" | relLangURL}}" class="dd-item">
-        <a href="{{"/" | relLangURL}}">
-          <i class="fa fa-fw fa-home"></i>
+        <a href="{{"/" | relLangURL}}" aria-label="Home">
+          <i class="fa fa-fw fa-home" aria-hidden="true"></i>
         </a>
       </li>
       {{- end}}
       {{- partial "menu.html" . }}
     </ul>
+    </nav>
 
     <section>
       {{- partial "menu-footer.html" . }}

--- a/themes/docdock/layouts/partials/menu.html
+++ b/themes/docdock/layouts/partials/menu.html
@@ -6,7 +6,7 @@
   <li class="dd-item back-to-dashboard">
     <div class="menu-item">
       <a href="{{ "/" | relLangURL }}" aria-label="Back to workshops dashboard" class="back-nav-link">
-        <i class="fa fa-angle-left fa-lg category-icon back-nav-icon"></i>
+        <i class="fa fa-angle-left fa-lg back-nav-icon" aria-hidden="true"></i>
       </a>
       <a href="{{ "/"| relLangURL }}">{{ i18n "workshop-dashboard" }}</a>
     </div>
@@ -52,12 +52,15 @@
       {{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}
     </a>
 
-    {{- if ne $numberOfPages 0 }} {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
-      <i class="fa fa-lg category-icon fa-angle-up"></i>
-    {{- else -}}
-      <i class="fa fa-angle-down fa-lg category-icon"></i>
+    {{- if ne $numberOfPages 0 }}
+      <button type="button" class="category-icon" aria-expanded="{{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}true{{- else }}false{{- end}}" aria-label="Toggle {{.Title}}">
+      {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+        <i class="fa fa-lg fa-angle-up" aria-hidden="true"></i>
+      {{- else -}}
+        <i class="fa fa-angle-down fa-lg" aria-hidden="true"></i>
+      {{- end}}
+      </button>
     {{- end}}
-  {{- end}}
   {{- if $showvisitedlinks}}
     <i class="fa fa-circle-thin read-icon"></i>
   {{end}}

--- a/themes/docdock/static/theme-flex/script.js
+++ b/themes/docdock/static/theme-flex/script.js
@@ -1,14 +1,9 @@
 jQuery(document).ready(function () {
-  jQuery(".category-icon").on("click", function () {
-    // Check if this is the back navigation icon
-    if ($(this).hasClass("back-nav-icon")) {
-      window.location.href = $(this).parent().attr("href");
-      return true;
-    }
-    
-    // Original dropdown behavior for other category icons
-    $(this).toggleClass("fa-angle-down fa-angle-up");
-    $(this).parent().parent().children("ul").toggle();
+  jQuery("button.category-icon").on("click", function () {
+    var $btn = $(this);
+    $btn.find("i").toggleClass("fa-angle-down fa-angle-up");
+    $btn.closest(".dd-item").children("ul").toggle();
+    $btn.attr("aria-expanded", $btn.attr("aria-expanded") === "true" ? "false" : "true");
     return false;
   });
 

--- a/themes/docdock/static/theme-flex/style.css
+++ b/themes/docdock/static/theme-flex/style.css
@@ -149,7 +149,13 @@ article > aside .menu .dd-item div * {
 article > aside .menu .dd-item div i.read-icon {
   display: none;
 }
-article > aside .menu .dd-item div i.category-icon {
+article > aside .menu .dd-item div button.category-icon {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
   display: flex;
   align-items: start;
   justify-content: center;
@@ -172,12 +178,17 @@ article > aside .menu .dd-item div a:active {
   border-radius: 0.2rem;
   padding: 0 0rem;
 }
-article > aside .menu .dd-item div i.category-icon:active,
-article > aside .menu .dd-item div i.category-icon:focus,
-article > aside .menu .dd-item div i.category-icon:hover {
+article > aside .menu .dd-item div button.category-icon:active,
+article > aside .menu .dd-item div button.category-icon:focus,
+article > aside .menu .dd-item div button.category-icon:hover {
   background-color: #eee;
   border-radius: 0.2rem;
   padding: 0 0rem;
+}
+article > aside .menu .dd-item div button.category-icon:focus-visible {
+  outline: 2px solid #4A90D9;
+  outline-offset: 1px;
+  border-radius: 0.2rem;
 }
 article > aside .menu .dd-item li {
   border-left: 1px solid #eee;
@@ -221,11 +232,13 @@ article > aside .menu .dd-item.back-to-dashboard div a {
   flex-basis: 20px !important;
 }
 
-article > aside .menu .dd-item.back-to-dashboard div a i.category-icon {
+article > aside .menu .dd-item.back-to-dashboard div a i.back-nav-icon {
   display: flex;
   align-items: start;
   justify-content: center;
   order: 1 !important;
+  width: 20px;
+  cursor: pointer;
 }
 
 article > aside .menu .dd-item.back-to-dashboard div a {


### PR DESCRIPTION
## Summary

Fixes #45 — Makes the sidebar navigation accessible to screen readers and keyboard users.

## Problem

The expand/collapse icons in the sidebar nav were `<i>` elements — not keyboard-focusable, no announced state, and invisible to assistive technology. A previous fix attempt that removed `<div>` wrappers broke CSS selectors and jQuery traversal since all three files (menu.html, style.css, script.js) are interdependent.

## Solution

Coordinated fix across all 4 interdependent files:

### menu.html
- Wrap expand/collapse icons in `<button type="button">` with `aria-expanded` (true/false) and `aria-label="Toggle {section title}"`
- Add `aria-hidden="true"` to decorative `<i>` elements inside buttons
- Separate back-nav icon from expand/collapse by removing `category-icon` class (back-nav works natively via `<a>` parent)

### body-beforecontent.html
- Add `<nav aria-label="Workshop navigation">` landmark wrapper
- Add `aria-label="Home"` and `aria-hidden="true"` to icon-only home link

### style.css
- Update selectors from `i.category-icon` to `button.category-icon`
- Add button reset styles (no border, background, margin)
- Add `:focus-visible` outline for keyboard navigation
- Update back-nav icon selector to target `.back-nav-icon` directly

### script.js
- Bind handler to `button.category-icon` (keyboard Enter/Space now works)
- Replace brittle `.parent().parent()` DOM traversal with `.closest('.dd-item')`
- Toggle `aria-expanded` on click
- Remove unnecessary back-nav special case

## Testing

- Hugo builds successfully with no errors
- Generated HTML verified: buttons render with correct `aria-expanded`, `aria-label` per section title
- `<nav>` landmark present on all pages
- Back-nav link unchanged (still `<a>` with `aria-label`)
- CSS descendant selectors still match through the new `<button>` wrapper
