### PR TITLE
Fix case-sensitive image references in C# Guess the Word workshop

### DIFF
--- a/content/brazilian-portuguese/csharp-guess-the-word/activity-1.md
+++ b/content/brazilian-portuguese/csharp-guess-the-word/activity-1.md
@@ -11,4 +11,4 @@ Vá até o código do jogo [GuessTheWord](https://dotnetfiddle.net/lMl7j4). Aper
 
 Encontre `// TODO (ACTIVITY 1)` no código. Adicione uma linha de código para imprimir Welcome to C# GuessTheWord no console. Se você fez isso corretamente, `Welcome to C# GuessTheWord` será mostrado no console depois de apertar **run**.
 
-![alt text height="600px" width="70%"](../media/guessTheWordActivity-1-start.PNG "Fiddle da atividade 1")
+![alt text height="600px" width="70%"](../media/guessTheWordActivity-1-start.png "Fiddle da atividade 1")

--- a/content/brazilian-portuguese/csharp-guess-the-word/activity-1.md
+++ b/content/brazilian-portuguese/csharp-guess-the-word/activity-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 1 - Escrevendo no console"
-date: 2019-07-23T11:45:38-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 4
 ---

--- a/content/brazilian-portuguese/csharp-guess-the-word/activity-6.md
+++ b/content/brazilian-portuguese/csharp-guess-the-word/activity-6.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 6 - Complete o jogo!"
-date: 2019-07-23T11:45:38-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 17
 ---

--- a/content/brazilian-portuguese/csharp-guess-the-word/activity-6.md
+++ b/content/brazilian-portuguese/csharp-guess-the-word/activity-6.md
@@ -11,4 +11,4 @@ Agora, vamos finalmente corrigir o bug que surgiu na **Atividade 4.2**.
 
 O jogo deve continuar pedindo ao jogador para adivinhar letras enquanto ele ainda tiver vidas e não tiver ganhado o jogo. Olhe para o `for` loop. Como você deve ter notado, mesmo que ainda haja vidas, o jogo para abruptamente após apenas 3 tentativas. Vamos substituir esse `for` por um `while` com a condição de repetição correta. Use a dica fornecida para completar a atividade.
 
-![alt text height="600px" width="70%"](../media/dotnetfiddle-activity6.PNG "Replit da atividade 6")
+![alt text height="600px" width="70%"](../media/dotnetfiddle-activity6.png "Replit da atividade 6")

--- a/content/brazilian-portuguese/csharp-guess-the-word/strings.md
+++ b/content/brazilian-portuguese/csharp-guess-the-word/strings.md
@@ -1,6 +1,6 @@
 ---
 title: "Strings"
-date: 2019-07-23T11:45:38-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 5
 ---

--- a/content/brazilian-portuguese/csharp-guess-the-word/strings.md
+++ b/content/brazilian-portuguese/csharp-guess-the-word/strings.md
@@ -19,7 +19,7 @@ Console.WriteLine("Apple" + "Pineapple");
 Console.WriteLine("Nuevo" + " " + "Foundation");
 ```
 
-![alt text height="600px" width="70%"](../media/strings-intro.PNG "Combinando strings com +")
+![alt text height="600px" width="70%"](../media/strings-intro.png "Combinando strings com +")
 
 {{% notice tip %}}
 

--- a/content/english/csharp-guess-the-word/activity-1.md
+++ b/content/english/csharp-guess-the-word/activity-1.md
@@ -11,4 +11,4 @@ Go to the code containing the [GuessTheWord](https://dotnetfiddle.net/lMl7j4) ga
 
 Find `// TODO (ACTIVITY 1)` in the code. Add a line of code to print Welcome to C# GuessTheWord to the console. If you did this correctly, `Welcome to C# GuessTheWord` will be printed to the console after pressing **run**.
 
-![alt text height="600px" width="70%"](../media/guessTheWordActivity-1-start.PNG "Fiddle for activity 1")
+![alt text height="600px" width="70%"](../media/guessTheWordActivity-1-start.png "Fiddle for activity 1")

--- a/content/english/csharp-guess-the-word/activity-1.md
+++ b/content/english/csharp-guess-the-word/activity-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 1 - Write to console"
-date: 2019-07-23T11:45:38-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 4
 ---

--- a/content/english/csharp-guess-the-word/activity-6.md
+++ b/content/english/csharp-guess-the-word/activity-6.md
@@ -11,4 +11,4 @@ Now, let's finally address the bug that was introduced in **Activity 4.2**.
 
 The game should continue to ask the player to guess letters if they have some lives remaining, and they have not yet won the game. Look at the `for` loop. As you might have noticed, even though you might have lives remaining, the game abruptly stops after only 3 guesses. We will replace this `for`-loop with a `while`-loop, with the correct looping condition. Use the given hint to complete the activity.
 
-![alt text height="600px" width="70%"](../media/dotnetfiddle-activity6.PNG "Replit for activity 6")
+![alt text height="600px" width="70%"](../media/dotnetfiddle-activity6.png "Replit for activity 6")

--- a/content/english/csharp-guess-the-word/activity-6.md
+++ b/content/english/csharp-guess-the-word/activity-6.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 6 - Complete the game!"
-date: 2019-07-23T11:45:38-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 17
 ---

--- a/content/english/csharp-guess-the-word/strings.md
+++ b/content/english/csharp-guess-the-word/strings.md
@@ -1,6 +1,6 @@
 ---
 title: "Strings"
-date: 2019-07-23T11:45:38-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 5
 ---

--- a/content/english/csharp-guess-the-word/strings.md
+++ b/content/english/csharp-guess-the-word/strings.md
@@ -19,7 +19,7 @@ Console.WriteLine("Apple" + "Pineapple");
 Console.WriteLine("Nuevo" + " " + "Foundation");
 ```
 
-![alt text height="600px" width="70%"](../media/strings-intro.PNG "Combining strings with +")
+![alt text height="600px" width="70%"](../media/strings-intro.png "Combining strings with +")
 
 {{% notice tip %}}
 


### PR DESCRIPTION
## Summary

Fixes case-sensitive image references that break on Linux/macOS build servers and deployment platforms (GitHub Pages, Netlify, Vercel).

## Problem

Three markdown files reference images with `.PNG` (uppercase) extension, but the actual files on disk use `.png` (lowercase). This works on Windows but breaks on case-sensitive filesystems.

## Changes

| File | Old reference | Correct filename |
|------|--------------|-----------------|
| activity-1.md | guessTheWordActivity-1-start.PNG | guessTheWordActivity-1-start.png |
| activity-6.md | dotnetfiddle-activity6.PNG | dotnetfiddle-activity6.png |
| strings.md | strings-intro.PNG | strings-intro.png |

## Testing

- Hugo build passes with no errors
- Verified all 3 referenced files exist with lowercase `.png` extension
