### PR TITLE
Fix image sizing and accessibility in Python Pixels workshop

### DIFF
--- a/content/brazilian-portuguese/python-pixel/Activities/Activity-1.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/Activity-1.md
@@ -21,7 +21,7 @@ Aqui está um exemplo de como fazer um quadro de cores com a cor vermelha, uma l
 
 Escolha sua cor favorita e faça um quadro de cores para brincar! Aqui estão algumas cores de exemplo que você pode escolher, mas também pode escolher sua própria cor.
 
-<img src="../../media/Color-chart.png" width="30%">
+<img src="../../media/Color-chart.png" alt="Tabela de cores RGB de exemplo" width="30%">
 
 <label for="colorpicker">Você pode usar o seletor de cores para escolher uma cor:</label>
 <input type="color" id="colorpicker">
@@ -31,10 +31,10 @@ Para ver sua imagem, clique no canto superior esquerdo (onde diz 'Files'), e dep
 <div style="width:70%">
     <table>
         <td>
-            <img src="../../media/open-file1.png" width="100%">
+            <img src="../../media/open-file1.png" alt="Clique em Arquivos no painel esquerdo" width="100%">
         </td>
         <td>
-            <img src="../../media/open-file2.png" width="100%">
+            <img src="../../media/open-file2.png" alt="Clique no arquivo de imagem para ver resultados" width="100%">
         </td>
     </table>
 </div>

--- a/content/brazilian-portuguese/python-pixel/Activities/Activity-1.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/Activity-1.md
@@ -15,26 +15,26 @@ Aqui está um exemplo de como fazer um quadro de cores com a cor vermelha, uma l
 
 `from PIL import Image; img = Image.new('RGB', (60, 30), 'red'); img.save('pil_red.png')`
 
-![alt text](../../media/whileloopbefore.png "imagem mostrando o primeiro exemplo da atividade")
+<img src="../../media/whileloopbefore.png" alt="Imagem mostrando primeiro exemplo da atividade" width="60%">
 
 ## Crie seu próprio quadro de cores!
 
 Escolha sua cor favorita e faça um quadro de cores para brincar! Aqui estão algumas cores de exemplo que você pode escolher, mas também pode escolher sua própria cor.
 
-<img src="../../media/Color-chart.png" width=30%>
+<img src="../../media/Color-chart.png" width="30%">
 
 <label for="colorpicker">Você pode usar o seletor de cores para escolher uma cor:</label>
 <input type="color" id="colorpicker">
 
 {{% notice warning %}}
 Para ver sua imagem, clique no canto superior esquerdo (onde diz 'Files'), e depois clique no arquivo de imagem para ver o resultado.
-<div style="width:100%">
+<div style="width:70%">
     <table>
         <td>
-            <img src="../../media/open-file1.png" width=100%>
+            <img src="../../media/open-file1.png" width="100%">
         </td>
         <td>
-            <img src="../../media/open-file2.png" width=100%>
+            <img src="../../media/open-file2.png" width="100%">
         </td>
     </table>
 </div>

--- a/content/brazilian-portuguese/python-pixel/Activities/Activity-1.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/Activity-1.md
@@ -2,7 +2,7 @@
 title: "Atividade 1: Crie um quadro de cores"
 prereq: "Fundamentos de Python, Manipulação de Imagens em Python: Abrir uma Imagem, Pixels em Python: Cores e Pixels"
 difficulties: ["intermediate"]
-date: 2020-07-11T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 1
 draft: false
 ---

--- a/content/brazilian-portuguese/python-pixel/Activities/Activity-2.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/Activity-2.md
@@ -27,11 +27,11 @@ img.save('pil_red.png')
 
 Esta é a imagem antes de adicionar a diagonal.  
 `imagem mostrando o primeiro exemplo com while`  
-![alt text](../../media/whileloopbefore.png "imagem mostrando o primeiro exemplo com while")
+<img src="../../media/whileloopbefore.png" alt="Imagem mostrando o primeiro exemplo com while" width="60%">
 
 Esta é a imagem depois de adicionar a diagonal.  
 `imagem mostrando o primeiro exemplo com while`  
-![alt text](../../media/whileloopafter.png "imagem mostrando o primeiro exemplo com while")
+<img src="../../media/whileloopafter.png" alt="Imagem mostrando resultado do while loop" width="60%">
 
 ## Exemplo dois: Faça um retângulo
 
@@ -47,11 +47,11 @@ img.save('pil_redmodified.png')
 
 Esta é a imagem antes de adicionar o retângulo.  
 `imagem mostrando o primeiro exemplo com for`  
-![alt text](../../media/whileloopbefore.png "imagem mostrando o primeiro exemplo com for")
+<img src="../../media/whileloopbefore.png" alt="Imagem mostrando o primeiro exemplo com for" width="60%">
 
 Esta é a imagem depois de adicionar o retângulo.  
 `imagem mostrando o primeiro exemplo com for`  
-![alt text](../../media/forloopafter.png "imagem mostrando o primeiro exemplo com for")
+<img src="../../media/forloopafter.png" alt="Imagem mostrando resultado do for loop" width="60%">
 
 ## Modifique seu próprio quadro de cores!
 

--- a/content/brazilian-portuguese/python-pixel/Activities/Activity-2.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/Activity-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 2: Modifique seu quadro de cores"
-date: 2020-07-11T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Fundamentos de Python, Pixels em Python: Cores e Pixels, Manipulação de Imagens em Python: Abrir uma imagem"
 difficulties: ["intermediate"]
 weight: 2

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-10.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-10.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 10: Criando um meme!"
-date: 2020-02-10T13:24:17-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 10
 prereq: "Fundamentos de Python, Pixels em Python: Cores e Pixels, Manipulação de Imagens em Python: Abrir uma imagem"

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-10.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-10.md
@@ -26,7 +26,7 @@ drawnImage.save("meuGatoComTexto.jpg")
 ```
 
 Minha imagem agora ficou assim:  
-<img src="../../media/meme.png" alt="gato em preto e branco de cabeça para baixo com texto: 'when you realize you learned python in an hour.'" width=50%>
+<img src="../../media/meme.png" alt="gato em preto e branco de cabeça para baixo com texto: 'when you realize you learned python in an hour.'" width="50%">
 
 ### Desafio – Mude a fonte
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-3.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-3.md
@@ -38,7 +38,7 @@ img.save('pixel-activity3.png')
 
 output:  
 `imagem mostrando o exemplo da atividade 3`  
-![alt text](../../media/Activity3_ex.png "imagem mostrando o exemplo da atividade 3")
+<img src="../../media/Activity3_ex.png" alt="Imagem mostrando exemplo da atividade 3" width="60%">
 
 ### Crie seu próprio elemento!
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-3.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-3.md
@@ -2,7 +2,7 @@
 title: "Atividade 3: Desafio: Crie novos elementos"
 prereq: "Fundamentos de Python, Manipulação de Imagens em Python: Abrir uma Imagem, Pixels em Python: Cores e Pixels"
 difficulties: ["intermediate"]
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 3
 draft: false
 ---

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-4.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-4.md
@@ -13,7 +13,7 @@ Agora que entendemos melhor sobre pixels e imagens, podemos começar a aprender 
 
 ### Exemplo de filtro azul
 
-<img src="../../media/cat.png" width=50%>  
+<img src="../../media/cat.png" width="50%">  
 Queremos adicionar um filtro azul no gatinho fofo acima. Vamos ver como fazer isso:
 
 ```python
@@ -34,7 +34,7 @@ img.save("Mycat.png")
 ```
 
 Uau! Aqui está o nosso gato com o filtro azul aplicado.  
-<img src="../../media/bluefiltercat.png" width=50%>
+<img src="../../media/bluefiltercat.png" width="50%">
 
 {{% notice tip %}}
 Como isso funciona? Vamos olhar o loop:

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-4.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-4.md
@@ -13,7 +13,7 @@ Agora que entendemos melhor sobre pixels e imagens, podemos começar a aprender 
 
 ### Exemplo de filtro azul
 
-<img src="../../media/cat.png" width="50%">  
+<img src="../../media/cat.png" alt="Imagem original do gato" width="50%">  
 Queremos adicionar um filtro azul no gatinho fofo acima. Vamos ver como fazer isso:
 
 ```python
@@ -34,7 +34,7 @@ img.save("Mycat.png")
 ```
 
 Uau! Aqui está o nosso gato com o filtro azul aplicado.  
-<img src="../../media/bluefiltercat.png" width="50%">
+<img src="../../media/bluefiltercat.png" alt="Imagem do gato com filtro azul aplicado" width="50%">
 
 {{% notice tip %}}
 Como isso funciona? Vamos olhar o loop:

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-4.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-4.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 4: Crie um Filtro Básico"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Fundamentos de Python, Pixels em Python: Cores e Pixels, Manipulação de Imagens em Python: Abrir uma imagem"
 difficulties: ["intermediate"]
 weight: 4

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-5.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-5.md
@@ -15,7 +15,7 @@ Na seção anterior, vimos como criar um filtro azul e pensamos sobre como fazer
 
 Vamos modificar a imagem do gatinho abaixo com nosso filtro cinza!
 
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -44,7 +44,7 @@ Qual é a melhor forma de “cinzar” um pixel? Podemos fazer a média entre os
 {{% /notice %}}
 
 Uau! Aqui está nosso gato com o filtro cinza:  
-<img src="../../media/greyfiltercat.png" width=50%>
+<img src="../../media/greyfiltercat.png" width="50%">
 
 ### Exemplo – Filtro parcial
 
@@ -69,7 +69,7 @@ img.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso gato com o filtro aplicado só em um quarto da imagem (canto superior esquerdo):  
-<img src="../../media/partialfilter.png" width=50%>
+<img src="../../media/partialfilter.png" width="50%">
 
 ### Desafio – Crie seu próprio filtro parcial
 
@@ -105,6 +105,6 @@ Vamos testar:
 ```
 
 Se você combinar `filter()` com `convert("L")`, terá algo como isto – purrfeito!  
-<img src="../../media/bw_upside_down.png" alt="gato preto e branco borrado de cabeça para baixo" width=50%>
+<img src="../../media/bw_upside_down.png" alt="gato preto e branco borrado de cabeça para baixo" width="50%">
 
 {{% /showanswer %}}

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-5.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-5.md
@@ -15,7 +15,7 @@ Na seção anterior, vimos como criar um filtro azul e pensamos sobre como fazer
 
 Vamos modificar a imagem do gatinho abaixo com nosso filtro cinza!
 
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Imagem original do gato" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -44,7 +44,7 @@ Qual é a melhor forma de “cinzar” um pixel? Podemos fazer a média entre os
 {{% /notice %}}
 
 Uau! Aqui está nosso gato com o filtro cinza:  
-<img src="../../media/greyfiltercat.png" width="50%">
+<img src="../../media/greyfiltercat.png" alt="Imagem do gato com filtro cinza aplicado" width="50%">
 
 ### Exemplo – Filtro parcial
 
@@ -69,7 +69,7 @@ img.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso gato com o filtro aplicado só em um quarto da imagem (canto superior esquerdo):  
-<img src="../../media/partialfilter.png" width="50%">
+<img src="../../media/partialfilter.png" alt="Imagem do gato com filtro parcial aplicado" width="50%">
 
 ### Desafio – Crie seu próprio filtro parcial
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-5.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 5: Filtros mais avançados"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Fundamentos de Python, Pixels em Python: Cores e Pixels, Manipulação de Imagens em Python: Abrir uma imagem"
 difficulties: ["intermediate"]
 weight: 5

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-6.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-6.md
@@ -15,7 +15,7 @@ Nesta seção, vamos aprender como recortar (cortar) uma imagem.
 
 Agora, vamos cortar a metade direita da imagem do gatinho.
 
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Imagem original do gato" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -39,13 +39,13 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Esse é nosso gato depois de ser recortado. Cortamos a metade direita da imagem!  
-<img src="../../media/halfcat.png" width="25%">
+<img src="../../media/halfcat.png" alt="Imagem do gato cortada pela metade" width="25%">
 
 ### Exemplo – Cortar só a parte central
 
 Vamos cortar a imagem do gato para deixar apenas a parte central!
 
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Imagem original do gato" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -69,7 +69,7 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Esse é nosso gato depois de recortar só o centro.  
-<img src="../../media/cropcat.png" width="25%">
+<img src="../../media/cropcat.png" alt="Imagem do gato com corte personalizado" width="25%">
 
 ### Desafio – Recorte a imagem do jeito que quiser!
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-6.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-6.md
@@ -15,7 +15,7 @@ Nesta seção, vamos aprender como recortar (cortar) uma imagem.
 
 Agora, vamos cortar a metade direita da imagem do gatinho.
 
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -39,13 +39,13 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Esse é nosso gato depois de ser recortado. Cortamos a metade direita da imagem!  
-<img src="../../media/halfcat.png" width=25%>
+<img src="../../media/halfcat.png" width="25%">
 
 ### Exemplo – Cortar só a parte central
 
 Vamos cortar a imagem do gato para deixar apenas a parte central!
 
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -69,7 +69,7 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Esse é nosso gato depois de recortar só o centro.  
-<img src="../../media/cropcat.png" width=25%>
+<img src="../../media/cropcat.png" width="25%">
 
 ### Desafio – Recorte a imagem do jeito que quiser!
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-6.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-6.md
@@ -2,7 +2,7 @@
 title: "Atividade 6: Recortar Imagem"
 prereq: "Fundamentos de Python, Manipulação de Imagens em Python: Abrir uma Imagem, Pixels em Python: Cores e Pixels"
 difficulties: ["intermediate"]
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 6
 draft: false
 ---

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-7.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-7.md
@@ -14,7 +14,7 @@ Nesta seção, vamos aprender como mudar o fundo simples de uma imagem usando pi
 ### Exemplo – Mudar a cor do fundo
 
 Vamos mudar o fundo da imagem da Nuvi para rosa.  
-<img src="../../media/nuevo.png" width=25%>
+<img src="../../media/nuevo.png" width="25%">
 
 ```python
 from PIL import Image
@@ -43,7 +43,7 @@ newimg.save("nuevopink.png")
 ```
 
 Uau! Aqui está a Nuvi com o novo fundo rosa.  
-<img src="../../media/nuevopink.png" width=25%>
+<img src="../../media/nuevopink.png" width="25%">
 
 ### Desafio – Mude o fundo com a cor que você quiser
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-7.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-7.md
@@ -14,7 +14,7 @@ Nesta seção, vamos aprender como mudar o fundo simples de uma imagem usando pi
 ### Exemplo – Mudar a cor do fundo
 
 Vamos mudar o fundo da imagem da Nuvi para rosa.  
-<img src="../../media/nuevo.png" width="25%">
+<img src="../../media/nuevo.png" alt="Logo da Nuevo Foundation" width="25%">
 
 ```python
 from PIL import Image
@@ -43,7 +43,7 @@ newimg.save("nuevopink.png")
 ```
 
 Uau! Aqui está a Nuvi com o novo fundo rosa.  
-<img src="../../media/nuevopink.png" width="25%">
+<img src="../../media/nuevopink.png" alt="Logo da Nuevo Foundation com fundo rosa" width="25%">
 
 ### Desafio – Mude o fundo com a cor que você quiser
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-7.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-7.md
@@ -2,7 +2,7 @@
 title: "Atividade 7: Mudar o fundo da imagem"
 prereq: "Fundamentos de Python, Manipulação de Imagens em Python: Abrir uma Imagem, Pixels em Python: Cores e Pixels"
 difficulties: ["intermediate"]
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 7
 draft: false
 ---

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
@@ -14,13 +14,13 @@ Nesta seção, vamos aprender como inverter sua imagem usando pixels.
 ### Exemplo – Inverter sua imagem de cabeça para baixo
 
 Vamos virar o gato de cabeça para baixo.  
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 {{% notice note %}}
 Virar a imagem de cabeça para baixo é o mesmo que criar uma imagem simétrica em relação à `linha central horizontal`, que é a linha preta na imagem abaixo.
 {{% /notice %}}
 
-<img src="../../media/cathori.png" width=50%>
+<img src="../../media/cathori.png" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -45,7 +45,7 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso novo gato depois de virar de cabeça para baixo.  
-<img src="../../media/flipcat.png" width=50%>
+<img src="../../media/flipcat.png" width="50%">
 
 Como descobrimos como definir `heightNew`?
 
@@ -71,7 +71,7 @@ for i in range(width):
 ```
 
 Por exemplo, tente aplicar esse código no seguinte grupo de letras 4x4:  
-<img src="../../media/table.png" width=15%>
+<img src="../../media/table.png" width="15%">
 
 Depois crie a versão espelhada usando a linha horizontal como base e compare com o resultado anterior. Ficaram iguais?
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
@@ -14,13 +14,13 @@ Nesta seção, vamos aprender como inverter sua imagem usando pixels.
 ### Exemplo – Inverter sua imagem de cabeça para baixo
 
 Vamos virar o gato de cabeça para baixo.  
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Imagem original do gato" width="50%">
 
 {{% notice note %}}
 Virar a imagem de cabeça para baixo é o mesmo que criar uma imagem simétrica em relação à `linha central horizontal`, que é a linha preta na imagem abaixo.
 {{% /notice %}}
 
-<img src="../../media/cathori.png" width="50%">
+<img src="../../media/cathori.png" alt="Imagem do gato espelhada horizontalmente" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -45,7 +45,7 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso novo gato depois de virar de cabeça para baixo.  
-<img src="../../media/flipcat.png" width="50%">
+<img src="../../media/flipcat.png" alt="Imagem original do gato" width="50%">
 
 Como descobrimos como definir `heightNew`?
 
@@ -71,7 +71,7 @@ for i in range(width):
 ```
 
 Por exemplo, tente aplicar esse código no seguinte grupo de letras 4x4:  
-<img src="../../media/table.png" width="15%">
+<img src="../../media/table.png" alt="Tabela de referencia de coordenadas de pixels" width="15%">
 
 Depois crie a versão espelhada usando a linha horizontal como base e compare com o resultado anterior. Ficaram iguais?
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 8: Inverta sua imagem"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Fundamentos de Python, Pixels em Python: Cores e Pixels, Manipulação de Imagens em Python: Abrir uma imagem"
 difficulties: ["intermediate"]
 weight: 8

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-8.md
@@ -45,7 +45,7 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso novo gato depois de virar de cabeça para baixo.  
-<img src="../../media/flipcat.png" alt="Imagem original do gato" width="50%">
+<img src="../../media/flipcat.png" alt="Imagem do gato virada de cabeça para baixo" width="50%">
 
 Como descobrimos como definir `heightNew`?
 

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-9.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-9.md
@@ -14,7 +14,7 @@ Nesta seção, vamos aprender como girar sua imagem usando pixels.
 ### Exemplo – Girar a imagem 180 graus no sentido horário
 
 Vamos girar nosso gatinho 180 graus no sentido horário.  
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -42,13 +42,13 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso novo gato após a rotação.  
-<img src="../../media/catrot.png" width=50%>
+<img src="../../media/catrot.png" width="50%">
 
 {{% notice note %}}
 Preste atenção em como calculamos `heightNew` e `widthNew`. Tente visualizar esses valores!
 
 Por exemplo, aplique esse cálculo ao grupo de letras 4x4 abaixo:  
-<img src="../../media/table.png" width=15%>
+<img src="../../media/table.png" width="15%">
 
 Depois gire o grupo 180 graus no sentido horário e compare o resultado. É o mesmo?
 {{% /notice %}}
@@ -88,6 +88,6 @@ Desafio: você consegue girar a imagem totalmente (360 graus)?
 E girar 3/4 de volta sem usar um ângulo maior que 180? (Dica: tente ângulos negativos!)
 
 Minha imagem girada totalmente ficou assim:  
-<img src="../../media/upside_down.png" alt="gato de cabeça para baixo" width=50%>
+<img src="../../media/upside_down.png" alt="gato de cabeça para baixo" width="50%">
 
 {{% /showanswer %}}

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-9.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-9.md
@@ -14,7 +14,7 @@ Nesta seção, vamos aprender como girar sua imagem usando pixels.
 ### Exemplo – Girar a imagem 180 graus no sentido horário
 
 Vamos girar nosso gatinho 180 graus no sentido horário.  
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Imagem original do gato" width="50%">
 
 ```python
 # Precisamos importar o pacote PIL para manipular pixels
@@ -42,13 +42,13 @@ newimg.save("Mycat.png")
 ```
 
 Uau! Aqui está nosso novo gato após a rotação.  
-<img src="../../media/catrot.png" width="50%">
+<img src="../../media/catrot.png" alt="Imagem do gato rotacionada" width="50%">
 
 {{% notice note %}}
 Preste atenção em como calculamos `heightNew` e `widthNew`. Tente visualizar esses valores!
 
 Por exemplo, aplique esse cálculo ao grupo de letras 4x4 abaixo:  
-<img src="../../media/table.png" width="15%">
+<img src="../../media/table.png" alt="Tabela de referencia de coordenadas de pixels" width="15%">
 
 Depois gire o grupo 180 graus no sentido horário e compare o resultado. É o mesmo?
 {{% /notice %}}

--- a/content/brazilian-portuguese/python-pixel/Activities/activity-9.md
+++ b/content/brazilian-portuguese/python-pixel/Activities/activity-9.md
@@ -1,6 +1,6 @@
 ---
 title: "Atividade 9: Rotacione sua imagem"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Fundamentos de Python, Pixels em Python: Cores e Pixels, Manipulação de Imagens em Python: Abrir uma imagem"
 difficulties: ["intermediate"]
 weight: 9

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/basic-of-colors.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/basic-of-colors.md
@@ -30,7 +30,7 @@ A cor representada por `(R, G, B)` é o resultado da mistura dessas três cores 
 Aqui estamos misturando quantidades diferentes de luz vermelha, verde e azul para criar novas cores. É parecido com a pintura com tinta, onde usamos pigmentos nas cores primárias vermelho, amarelo e azul. Mas no computador usamos luz — com as cores primárias vermelho, verde e azul.
 
 Esta imagem mostra, de forma aproximada, como as cores se combinam:  
-![alt text iframe height="600px" width="40%"](../../media/colors.svg.png "representação de mistura de cores")
+<img src="../../media/colors.svg.png" alt="Representação de mistura de cores" width="50%">
 
 Assim como não devemos usar tinta demais, há um limite para representar cores com luz:  
 O valor máximo de cada cor no RGB é `255` e o mínimo é `0`.
@@ -50,7 +50,7 @@ Em todo o restante do material, "cor" significa "cor da luz".
 
 {{% showanswer "Mostrar Resposta" %}}
 Preto. Todos os valores são 0%. (Não há luz — está tudo escuro. É preto!)
-![alt text height="600px" width="40%"](../../media/black.png "preto")
+<img src="../../media/black.png" alt="Amostra de cor preta" width="40%">
 </br>
 {{% /showanswer %}}
 
@@ -63,7 +63,7 @@ Preto. Todos os valores são 0%. (Não há luz — está tudo escuro. É preto!)
 
 {{% showanswer "Mostrar Resposta" %}}
 Branco. 255 significa que estamos usando 100% de cada cor — totalmente saturado. Quando todas estão no máximo, o resultado é branco.
-![alt text height="600px" width="40%"](../../media/white.png "branco")
+<img src="../../media/white.png" alt="Amostra de cor branca" width="40%">
 </br>
 {{% /showanswer %}}
 
@@ -76,7 +76,7 @@ Branco. 255 significa que estamos usando 100% de cada cor — totalmente saturad
 
 {{% showanswer "Mostrar Resposta" %}}
 Cinza. `100 / 255` = aproximadamente 39,2%. Misturando 39,2% de vermelho, verde e azul obtemos cinza.
-![alt text height="600px" width="40%"](../../media/grey.png "cinza")
+<img src="../../media/grey.png" alt="Amostra de cor cinza" width="40%">
 </br>
 {{% /showanswer %}}
 
@@ -104,6 +104,6 @@ img.show('red.png')
 
 A saída será:
 
-![alt text](../../media/whileloopbefore.png "vermelho")
+<img src="../../media/whileloopbefore.png" alt="Exemplo de saída de cor vermelha" width="60%">
 
 Incrível! Você obteve vermelho!

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/load_image_module.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/load_image_module.md
@@ -1,6 +1,6 @@
 ---
 title: "Importar um módulo de imagem"
-date: 2020-02-10T13:24:17-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 1
 ---

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/load_image_module.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/load_image_module.md
@@ -19,7 +19,7 @@ Depois, adicione as instruções abaixo:
 
 Assim que você clicar em "Run", verá que o módulo será instalado no console:
 
-![alt text](../../media/installed_module.png "imagem do console mostrando o módulo instalado com sucesso")
+<img src="../../media/installed_module.png" alt="Imagem do console mostrando o módulo instalado com sucesso" width="60%">
 
 Se você viu isso, parabéns! Você importou o módulo com sucesso.  
 Se estiver com problemas, peça ajuda antes de continuar.

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/open-image.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/open-image.md
@@ -12,7 +12,7 @@ Depois que a imagem estiver salva, volte para a janela do Replit e envie o arqui
 
 Por exemplo, para enviar o arquivo `cat.jpg`:
 
-![alt text](../../media/upload_file.png "imagem mostrando como enviar um arquivo")
+<img src="../../media/upload_file.png" alt="Imagem mostrando como enviar um arquivo" width="60%">
 
 Você verá o arquivo JPG aparecer no lado esquerdo da tela após o upload.  
 Note que sua imagem pode ter uma extensão diferente (como .png, .jpeg etc.).
@@ -34,4 +34,4 @@ O código acima abre a imagem e armazena ela na variável `image`. Depois, salva
 Clique em **Run** e veja a imagem aparecer!  
 A minha imagem ficou assim:
 
-<img src="../../media/cat.png" alt="gato" width=50%>
+<img src="../../media/cat.png" alt="gato" width="50%">

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/open-image.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/open-image.md
@@ -1,6 +1,6 @@
 ---
 title: "Abrir uma imagem"
-date: 2020-02-10T13:24:17-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 2
 ---

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/pixel-on-image.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/pixel-on-image.md
@@ -14,10 +14,10 @@ Quando vemos uma imagem na tela, ela é composta por muitos pixels coloridos, ma
 <div style="width:80%;padding-left:20%;">
     <table>
         <td>
-            <img src="../../media/nuvi.png" width="100%">
+            <img src="../../media/nuvi.png" alt="Personagem Nuvi" width="100%">
         </td>
         <td>
-            <img src="../../media/pixel-nuvi.png" width="100%">
+            <img src="../../media/pixel-nuvi.png" alt="Personagem Nuvi mostrado como pixels" width="100%">
         </td>
     </table>
 </div>

--- a/content/brazilian-portuguese/python-pixel/colors_and_pixels/pixel-on-image.md
+++ b/content/brazilian-portuguese/python-pixel/colors_and_pixels/pixel-on-image.md
@@ -14,10 +14,10 @@ Quando vemos uma imagem na tela, ela é composta por muitos pixels coloridos, ma
 <div style="width:80%;padding-left:20%;">
     <table>
         <td>
-            <img src="../../media/nuvi.png" width=100%>
+            <img src="../../media/nuvi.png" width="100%">
         </td>
         <td>
-            <img src="../../media/pixel-nuvi.png" width=100%>
+            <img src="../../media/pixel-nuvi.png" width="100%">
         </td>
     </table>
 </div>
@@ -49,7 +49,7 @@ img.save('pil_grey.png')
 ```
 
 A variável `img` guarda a imagem PNG, que fica assim:  
-![alt text](../../media/grey.png "Imagem cinza gerada por pixels")
+<img src="../../media/grey.png" alt="Imagem cinza gerada por pixels" width="40%">
 
 ```python
 # Lembre-se de importar Image
@@ -59,7 +59,7 @@ img.save('pil_black.png')
 ```
 
 Aqui, ao especificar `"black"` como cor RGB, criamos e salvamos esta imagem:  
-![alt text](../../media/black.png "Imagem preta gerada por pixels")
+<img src="../../media/black.png" alt="Imagem preta gerada por pixels" width="40%">
 
 ## Alterando um pixel na imagem
 
@@ -80,4 +80,4 @@ img.save('pil_black-dot.png')
 Após criar uma imagem amarela de 200x100, a função `putpixel` coloca um pequeno ponto preto bem no meio do bloco amarelo.  
 Esse ponto é apenas 1 pixel – talvez você precise ampliar a imagem para enxergar!
 
-![alt text](../../media/black-dot.png "Imagem mostrando ponto preto em fundo amarelo")
+<img src="../../media/black-dot.png" alt="Imagem mostrando ponto preto em fundo amarelo" width="40%">

--- a/content/english/python-pixel/Activities/Activity-1.md
+++ b/content/english/python-pixel/Activities/Activity-1.md
@@ -19,13 +19,13 @@ from PIL import Image
 img = Image.new('RGB', (60, 30), 'red')
 img.save('pil_red.png')
 ```
-![alt text](../../media/whileloopbefore.png "image showing activity one first example")
+<img src="../../media/whileloopbefore.png" alt="Image showing activity one first example" width="60%">
 
 ## Create your own colorboard!
 
 Choose your favorite color and make a color board to play with! Here are some example colors you can choose from, but you can also pick your own color.
 
-<img src="../../media/Color-chart.png" width=30%>
+<img src="../../media/Color-chart.png" alt="Color chart showing example RGB colors" width="30%">
 
 <!-- For accessibility, use this label HTML -->
 <label for="colorpicker">You can use color picker to choose a color:</label>
@@ -33,13 +33,13 @@ Choose your favorite color and make a color board to play with! Here are some ex
 
 {{% notice warning %}}
  In order to see your image, please click on top left corner (which says 'Files'), and then click on the image file to see the result.
-<div style="width:100%">
+<div style="width:70%">
     <table>
         <td>
-            <img src="../../media/open-file1.png" width=100%>
+            <img src="../../media/open-file1.png" alt="Click Files in the left panel" width="100%">
         </td>
         <td>
-            <img src="../../media/open-file2.png" width=100%>
+            <img src="../../media/open-file2.png" alt="Click the image file to see results" width="100%">
         </td>
     </table>
 </div>

--- a/content/english/python-pixel/Activities/Activity-1.md
+++ b/content/english/python-pixel/Activities/Activity-1.md
@@ -2,7 +2,7 @@
 title: "Activity 1: Create a color board"
 prereq: "Python Basics, Python Image Manipulation: Open an Image, Python Pixels: Colors and Pixels"
 difficulties: ["intermediate"]
-date: 2020-07-11T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 1
 draft: false
 ---

--- a/content/english/python-pixel/Activities/Activity-2.md
+++ b/content/english/python-pixel/Activities/Activity-2.md
@@ -29,10 +29,10 @@ img.save('pil_red.png')
 ```
 
 This is the picture before adding the diagonal.
-![alt text](../../media/whileloopbefore.png "image showing while loop first example")
+<img src="../../media/whileloopbefore.png" alt="Image showing while loop first example" width="60%">
 
 This is the picture after adding the diagonal.
-![alt text](../../media/whileloopafter.png "image showing while loop first example")
+<img src="../../media/whileloopafter.png" alt="Image showing while loop first example result" width="60%">
 
 ## Example two: Make a rectangle.
 
@@ -49,10 +49,10 @@ img.save('pil_redmodified.png')
 ```
 
 This is the picture before adding the rectangle.
-![alt text](../../media/whileloopbefore.png "image showing for loop first example")
+<img src="../../media/whileloopbefore.png" alt="Image showing for loop first example" width="60%">
 
 This is the picture after adding the rectangle.
-![alt text](../../media/forloopafter.png "image showing for loop first example")
+<img src="../../media/forloopafter.png" alt="Image showing for loop first example result" width="60%">
 
 ## Modifying your own colorboard!
 

--- a/content/english/python-pixel/Activities/Activity-2.md
+++ b/content/english/python-pixel/Activities/Activity-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 2: Modify your color board"
-date: 2020-07-11T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Python Basics, Python Pixels: Colors and Pixels, Python Image manipulation: Open an image"
 difficulties: ["intermediate"]
 weight: 2

--- a/content/english/python-pixel/Activities/activity-10.md
+++ b/content/english/python-pixel/Activities/activity-10.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 10: Making a meme!"
-date: 2020-02-10T13:24:17-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 10
 prereq: "Python Basics, Python Pixels: Colors and Pixels, Python Image manipulation: Open an image"

--- a/content/english/python-pixel/Activities/activity-10.md
+++ b/content/english/python-pixel/Activities/activity-10.md
@@ -27,7 +27,7 @@ For example:
 
 
 My image now looks like this:
-<img src="../../media/meme.png" alt="blurred black and white cat upside down with text that says `when you realize you learned python in an hour.`" width=50%>
+<img src="../../media/meme.png" alt="blurred black and white cat upside down with text that says `when you realize you learned python in an hour.`" width="50%">
 
 ### Challenge - Change the font
 You can see that the text in the image created above is in a small, default font. There are other parameters within the `text()` method you can use. Take a look at the [documentation](https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html#PIL.ImageDraw.PIL.ImageDraw.ImageDraw.text) and see if you can change the font and the font size, as well as the color of the text! 

--- a/content/english/python-pixel/Activities/activity-3.md
+++ b/content/english/python-pixel/Activities/activity-3.md
@@ -38,7 +38,7 @@ for y in range(5, 25):
 img.save('pixel-activity3.png')
 ```
 output:
-![alt text](../../media/Activity3_ex.png "image showing activity3 example")
+<img src="../../media/Activity3_ex.png" alt="Image showing activity 3 example" width="60%">
 
 
 ### Design your own element!

--- a/content/english/python-pixel/Activities/activity-3.md
+++ b/content/english/python-pixel/Activities/activity-3.md
@@ -2,7 +2,7 @@
 title: "Activity 3: Challenge: Design new elements"
 prereq: "Python Basics, Python Image Manipulation: Open an Image, Python Pixels: Colors and Pixels"
 difficulties: ["intermediate"]
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 3
 draft: false
 ---

--- a/content/english/python-pixel/Activities/activity-4.md
+++ b/content/english/python-pixel/Activities/activity-4.md
@@ -13,7 +13,7 @@ Now that we understand more about pixels and images, we can start to learn how t
 
 ### Example for blue filter
 
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Original cat image" width="50%">
 We want to add a blue filter on the cute cat above. Let's see how to achieve that.
 
 ```python
@@ -34,7 +34,7 @@ img.save("Mycat.png")
 ```
 
 Wow! This is our cat after the blue filter.
-<img src="../../media/bluefiltercat.png" width="50%">
+<img src="../../media/bluefiltercat.png" alt="Original cat image" width="50%">
 
 {{% notice tip %}}
 How did this work? Let's look at the loop: 

--- a/content/english/python-pixel/Activities/activity-4.md
+++ b/content/english/python-pixel/Activities/activity-4.md
@@ -13,7 +13,7 @@ Now that we understand more about pixels and images, we can start to learn how t
 
 ### Example for blue filter
 
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 We want to add a blue filter on the cute cat above. Let's see how to achieve that.
 
 ```python
@@ -34,7 +34,7 @@ img.save("Mycat.png")
 ```
 
 Wow! This is our cat after the blue filter.
-<img src="../../media/bluefiltercat.png" width=50%>
+<img src="../../media/bluefiltercat.png" width="50%">
 
 {{% notice tip %}}
 How did this work? Let's look at the loop: 

--- a/content/english/python-pixel/Activities/activity-4.md
+++ b/content/english/python-pixel/Activities/activity-4.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 4: Create Basic Filter"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Python Basics, Python Pixels: Colors and Pixels, Python Image manipulation: Open an image"
 difficulties: ["intermediate"]
 weight: 4

--- a/content/english/python-pixel/Activities/activity-4.md
+++ b/content/english/python-pixel/Activities/activity-4.md
@@ -34,7 +34,7 @@ img.save("Mycat.png")
 ```
 
 Wow! This is our cat after the blue filter.
-<img src="../../media/bluefiltercat.png" alt="Original cat image" width="50%">
+<img src="../../media/bluefiltercat.png" alt="Cat image with blue filter applied" width="50%">
 
 {{% notice tip %}}
 How did this work? Let's look at the loop: 

--- a/content/english/python-pixel/Activities/activity-5.md
+++ b/content/english/python-pixel/Activities/activity-5.md
@@ -16,7 +16,7 @@ In the last section, we saw an example of creating a blue filter and thought abo
 
 Let us change the original cat image below with our grey filter together! 
 
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -45,7 +45,7 @@ How can we best figure out how to set a pixel to be the 'greyed' version of it? 
 
 Wow! This is our cat after the grey filter.
   
-<img src="../../media/greyfiltercat.png" width=50%>
+<img src="../../media/greyfiltercat.png" width="50%">
 
 ### Example - Partial filter
 
@@ -71,7 +71,7 @@ img.save("Mycat.png")
 
 Wow! This is our cat after the filter. We only filtered one-forth of the cat on the upper left corner！
 
-<img src="../../media/partialfilter.png" width=50%>
+<img src="../../media/partialfilter.png" width="50%">
 
 ### Challenge - Create your own partial filter
 
@@ -105,7 +105,7 @@ Let’s try it out like this:
 
 If you combine the blurred function and the black and white convert function, you'll get something like this – purrfect!
 
-<img src="../../media/bw_upside_down.png" alt="blurred black and white cat upside down" width=50%>
+<img src="../../media/bw_upside_down.png" alt="blurred black and white cat upside down" width="50%">
 </br>
 {{% /showanswer %}}
 

--- a/content/english/python-pixel/Activities/activity-5.md
+++ b/content/english/python-pixel/Activities/activity-5.md
@@ -16,7 +16,7 @@ In the last section, we saw an example of creating a blue filter and thought abo
 
 Let us change the original cat image below with our grey filter together! 
 
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Original cat image" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -45,7 +45,7 @@ How can we best figure out how to set a pixel to be the 'greyed' version of it? 
 
 Wow! This is our cat after the grey filter.
   
-<img src="../../media/greyfiltercat.png" width="50%">
+<img src="../../media/greyfiltercat.png" alt="Cat image with greyscale filter applied" width="50%">
 
 ### Example - Partial filter
 
@@ -71,7 +71,7 @@ img.save("Mycat.png")
 
 Wow! This is our cat after the filter. We only filtered one-forth of the cat on the upper left corner！
 
-<img src="../../media/partialfilter.png" width="50%">
+<img src="../../media/partialfilter.png" alt="Cat image with partial filter applied" width="50%">
 
 ### Challenge - Create your own partial filter
 

--- a/content/english/python-pixel/Activities/activity-5.md
+++ b/content/english/python-pixel/Activities/activity-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 5: More advanced filters"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Python Basics, Python Pixels: Colors and Pixels, Python Image manipulation: Open an image"
 difficulties: ["intermediate"]
 weight: 5

--- a/content/english/python-pixel/Activities/activity-6.md
+++ b/content/english/python-pixel/Activities/activity-6.md
@@ -15,7 +15,7 @@ In this section, we will start to learn how to crop your image.
 
 Now, let us crop out the right half of the cat image.
   
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -40,13 +40,13 @@ newimg.save("Mycat.png")
 
 Wow! This is our cat after the cropping. We cropped the right half of the image!
 
-<img src="../../media/halfcat.png" width=25%>
+<img src="../../media/halfcat.png" width="25%">
 
 ### Example - Crop out the central piece
 
 Let us crop the cat image to have only the center part!
 
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -70,7 +70,7 @@ newimg.save("Mycat.png")
 ```
 
 Wow! This is our cat after cropping.
-<img src="../../media/cropcat.png" width=25%>
+<img src="../../media/cropcat.png" width="25%">
 
 ### Challenge - Crop image based on your own choice
 

--- a/content/english/python-pixel/Activities/activity-6.md
+++ b/content/english/python-pixel/Activities/activity-6.md
@@ -15,7 +15,7 @@ In this section, we will start to learn how to crop your image.
 
 Now, let us crop out the right half of the cat image.
   
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Original cat image" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -40,13 +40,13 @@ newimg.save("Mycat.png")
 
 Wow! This is our cat after the cropping. We cropped the right half of the image!
 
-<img src="../../media/halfcat.png" width="25%">
+<img src="../../media/halfcat.png" alt="Cat image cropped to left half" width="25%">
 
 ### Example - Crop out the central piece
 
 Let us crop the cat image to have only the center part!
 
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Original cat image" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -70,7 +70,7 @@ newimg.save("Mycat.png")
 ```
 
 Wow! This is our cat after cropping.
-<img src="../../media/cropcat.png" width="25%">
+<img src="../../media/cropcat.png" alt="Cat image with custom crop applied" width="25%">
 
 ### Challenge - Crop image based on your own choice
 

--- a/content/english/python-pixel/Activities/activity-6.md
+++ b/content/english/python-pixel/Activities/activity-6.md
@@ -2,7 +2,7 @@
 title: "Activity 6: Crop Image"
 prereq: "Python Basics, Python Image Manipulation: Open an Image, Python Pixel: Colors and Pixels"
 difficulties: ["intermediate"]
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 6
 draft: false
 ---

--- a/content/english/python-pixel/Activities/activity-7.md
+++ b/content/english/python-pixel/Activities/activity-7.md
@@ -14,7 +14,7 @@ In this section, we will start to learn how to change the simple background of y
 ### Example - Change background color
 
 Let us change the background color of Nuvi to pink.
-<img src="../../media/nuevo.png" width=25%>
+<img src="../../media/nuevo.png" width="25%">
 
 ```python
 from PIL import Image
@@ -43,7 +43,7 @@ newimg.save("nuevopink.png")
 ```
 
 Wow! This is our new Nuvi after changing the background.
-<img src="../../media/nuevopink.png" width=25%>
+<img src="../../media/nuevopink.png" width="25%">
 
 
 ### Challenge - Change background based on your choice

--- a/content/english/python-pixel/Activities/activity-7.md
+++ b/content/english/python-pixel/Activities/activity-7.md
@@ -14,7 +14,7 @@ In this section, we will start to learn how to change the simple background of y
 ### Example - Change background color
 
 Let us change the background color of Nuvi to pink.
-<img src="../../media/nuevo.png" width="25%">
+<img src="../../media/nuevo.png" alt="Nuevo Foundation logo" width="25%">
 
 ```python
 from PIL import Image
@@ -43,7 +43,7 @@ newimg.save("nuevopink.png")
 ```
 
 Wow! This is our new Nuvi after changing the background.
-<img src="../../media/nuevopink.png" width="25%">
+<img src="../../media/nuevopink.png" alt="Nuevo Foundation logo with pink background" width="25%">
 
 
 ### Challenge - Change background based on your choice

--- a/content/english/python-pixel/Activities/activity-7.md
+++ b/content/english/python-pixel/Activities/activity-7.md
@@ -2,7 +2,7 @@
 title: "Activity 7: Change the background of image"
 prereq: "Python Basics, Python Image Manipulation: Open an Image, Python Pixel: Colors and Pixels"
 difficulties: ["intermediate"]
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 weight: 7
 draft: false
 ---

--- a/content/english/python-pixel/Activities/activity-8.md
+++ b/content/english/python-pixel/Activities/activity-8.md
@@ -14,7 +14,7 @@ In this section, we will start to learn how to flip your image using pixels.
 ### Example - Flip your image upside down
 
 Let us flip the cat upside down.
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 {{% notice note %}}
 
@@ -22,7 +22,7 @@ Flipping the image upside down is the same as creating a symmetrical image with 
 
 {{% /notice %}}
 
-<img src="../../media/cathori.png" width=50%>
+<img src="../../media/cathori.png" width="50%">
 
 ```python
 # We need to import PIL package to manipulation with pixels.
@@ -48,7 +48,7 @@ newimg.save("Mycat.png")
 
 Wow! This is our new cat after flipping.
 
-<img src="../../media/flipcat.png" width=50%>
+<img src="../../media/flipcat.png" width="50%">
 
 How did we figure out how to set `heightNew`? In the above code we have:
 
@@ -77,7 +77,7 @@ for i in range(width): # For every column
 
 For example, try to apply this code on the following 4x4 letter group:
 
-<img src="../../media/table.png" width=15%>
+<img src="../../media/table.png" width="15%">
 
 Then create the symmetrical output with respect to horizontal central line and compare it with the previous output. Are they the same?
 

--- a/content/english/python-pixel/Activities/activity-8.md
+++ b/content/english/python-pixel/Activities/activity-8.md
@@ -14,7 +14,7 @@ In this section, we will start to learn how to flip your image using pixels.
 ### Example - Flip your image upside down
 
 Let us flip the cat upside down.
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Original cat image" width="50%">
 
 {{% notice note %}}
 
@@ -22,7 +22,7 @@ Flipping the image upside down is the same as creating a symmetrical image with 
 
 {{% /notice %}}
 
-<img src="../../media/cathori.png" width="50%">
+<img src="../../media/cathori.png" alt="Cat image flipped horizontally" width="50%">
 
 ```python
 # We need to import PIL package to manipulation with pixels.
@@ -48,7 +48,7 @@ newimg.save("Mycat.png")
 
 Wow! This is our new cat after flipping.
 
-<img src="../../media/flipcat.png" width="50%">
+<img src="../../media/flipcat.png" alt="Original cat image" width="50%">
 
 How did we figure out how to set `heightNew`? In the above code we have:
 
@@ -77,7 +77,7 @@ for i in range(width): # For every column
 
 For example, try to apply this code on the following 4x4 letter group:
 
-<img src="../../media/table.png" width="15%">
+<img src="../../media/table.png" alt="Pixel coordinate reference table" width="15%">
 
 Then create the symmetrical output with respect to horizontal central line and compare it with the previous output. Are they the same?
 

--- a/content/english/python-pixel/Activities/activity-8.md
+++ b/content/english/python-pixel/Activities/activity-8.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 8: Flip your image"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Python Basics, Python Pixels: Colors and Pixels, Python Image manipulation: Open an image"
 difficulties: ["intermediate"]
 weight: 8

--- a/content/english/python-pixel/Activities/activity-8.md
+++ b/content/english/python-pixel/Activities/activity-8.md
@@ -48,7 +48,7 @@ newimg.save("Mycat.png")
 
 Wow! This is our new cat after flipping.
 
-<img src="../../media/flipcat.png" alt="Original cat image" width="50%">
+<img src="../../media/flipcat.png" alt="Cat image flipped upside down" width="50%">
 
 How did we figure out how to set `heightNew`? In the above code we have:
 

--- a/content/english/python-pixel/Activities/activity-9.md
+++ b/content/english/python-pixel/Activities/activity-9.md
@@ -14,7 +14,7 @@ In this section, we will start to learn how to rotate your image using pixels.
 ### Example - Rotate your image 180 degree clock-wise
 
 Let us rotate our cat 180 degrees clock-wise.
-<img src="../../media/cat.png" width=50%>
+<img src="../../media/cat.png" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -44,7 +44,7 @@ newimg.save("Mycat.png")
 ```
 
 Wow! This is our new cat after rotating.
-<img src="../../media/catrot.png" width=50%>
+<img src="../../media/catrot.png" width="50%">
 
 {{% notice note %}}
 
@@ -52,7 +52,7 @@ Pay attention to how we get our heightNew and widthNew. Think about those variab
 
 For example, try to apply them on the following 4x4 letter group:
 
-<img src="../../media/table.png" width=15%>
+<img src="../../media/table.png" width="15%">
 
 Then rotate it 180 degree clockwise and compare it with the previous output. Are they the same?
 {{% /notice %}}
@@ -93,7 +93,7 @@ way around without using an angle > 180? (Hint: try using negative angle numbers
 
 Rotated all the way around, my image looks like this:
 
-<img src="../../media/upside_down.png" alt="cat upside down" width=50%>
+<img src="../../media/upside_down.png" alt="cat upside down" width="50%">
 </br>
 {{% /showanswer %}}
 

--- a/content/english/python-pixel/Activities/activity-9.md
+++ b/content/english/python-pixel/Activities/activity-9.md
@@ -14,7 +14,7 @@ In this section, we will start to learn how to rotate your image using pixels.
 ### Example - Rotate your image 180 degree clock-wise
 
 Let us rotate our cat 180 degrees clock-wise.
-<img src="../../media/cat.png" width="50%">
+<img src="../../media/cat.png" alt="Original cat image" width="50%">
 
 ```python
 # We need to import PIL package to allow manipulation with pixels.
@@ -44,7 +44,7 @@ newimg.save("Mycat.png")
 ```
 
 Wow! This is our new cat after rotating.
-<img src="../../media/catrot.png" width="50%">
+<img src="../../media/catrot.png" alt="Cat image rotated" width="50%">
 
 {{% notice note %}}
 
@@ -52,7 +52,7 @@ Pay attention to how we get our heightNew and widthNew. Think about those variab
 
 For example, try to apply them on the following 4x4 letter group:
 
-<img src="../../media/table.png" width="15%">
+<img src="../../media/table.png" alt="Pixel coordinate reference table" width="15%">
 
 Then rotate it 180 degree clockwise and compare it with the previous output. Are they the same?
 {{% /notice %}}

--- a/content/english/python-pixel/Activities/activity-9.md
+++ b/content/english/python-pixel/Activities/activity-9.md
@@ -1,6 +1,6 @@
 ---
 title: "Activity 9: Rotate your image"
-date: 2020-09-08T00:00:00Z
+date: 2026-04-25T00:00:00-07:00
 prereq: "Python Basics, Python Pixels: Colors and Pixels, Python Image manipulation: Open an image"
 difficulties: ["intermediate"]
 weight: 9

--- a/content/english/python-pixel/colors_and_pixels/basic-of-colors.md
+++ b/content/english/python-pixel/colors_and_pixels/basic-of-colors.md
@@ -25,7 +25,7 @@ In Python, we follow a specific format when defining colors:
 Here we are using different amounts of red, green and blue light to get a new color of light. Just like we use different amounts of pigments while painting, we are mixing different amounts of lights to create different colors of light.  Pigments use the primary colors of red, yellow and blue, whereas computers use primary colors of red, green and blue light. 
 
 This picture represents very approximately how colors mix up:
-![alt text iframe height="600px" width="40%"](../../media/colors.svg.png "color representation")
+<img src="../../media/colors.svg.png" alt="Color representation showing how red, green, and blue light mix together" width="50%">
 
 Just as we should not use too much pigment, there is also limitation for representing colors. The maximum integer we can use to represent each amount of color is 255 and the minimum integer we can use to represent each amount of color is 0. This is defined in RGB mode.
 
@@ -44,7 +44,7 @@ style="display:inline-block;width:40%;height:100px;">
 
 {{% showanswer "Show Answer" %}}
 Black. All colors are of 0%. (There is no color here. The whole world is so dark. It is black!)
-![alt text height="600px" width="40%"](../../media/black.png "black")
+<img src="../../media/black.png" alt="Black color sample" width="40%">
 </br>
 {{% /showanswer %}}
 
@@ -58,7 +58,7 @@ style="display:inline-block;width:40%;height:100px;">
 
 {{% showanswer "Show Answer" %}}
 White. 255 represents that you are using 100% of each color, which is saturate. (When all colors are saturate, you will get white)
-![alt text height="600px" width="40%"](../../media/white.png "white")
+<img src="../../media/white.png" alt="White color sample" width="40%">
 </br>
 {{% /showanswer %}}
 
@@ -72,7 +72,7 @@ style="display:inline-block;width:40%;height:100px;">
 
 {{% showanswer "Show Answer" %}}
 Gray. 100 / 255 % = 39.2%. You will get gray by adding up 39.2% of red, 39.2% of blue, and 39.2% of green.
-![alt text height="600px" width="40%"](../../media/grey.png "gray")
+<img src="../../media/grey.png" alt="Gray color sample" width="40%">
 </br>
 {{% /showanswer %}}
 
@@ -96,5 +96,5 @@ img.save('red.png')
 img.show('red.png')
 ```
 The following is your output:
-![alt text](../../media/whileloopbefore.png "red")
+<img src="../../media/whileloopbefore.png" alt="Red color output example" width="60%">
 Amazing! You get red!

--- a/content/english/python-pixel/colors_and_pixels/load_image_module.md
+++ b/content/english/python-pixel/colors_and_pixels/load_image_module.md
@@ -1,6 +1,6 @@
 ---
 title: "Import an image module"
-date: 2020-02-10T13:24:17-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 1
 --- 

--- a/content/english/python-pixel/colors_and_pixels/load_image_module.md
+++ b/content/english/python-pixel/colors_and_pixels/load_image_module.md
@@ -19,7 +19,7 @@ First, let’s delete everything in the main.py file. Then, add the following st
 
 Once you hit run, you should see the module being installed in the console:
 
-![alt text](../../media/installed_module.png "image of what you should see when you successfully install the module")
+<img src="../../media/installed_module.png" alt="Image of what you should see when you successfully install the module" width="60%">
 
 If you see the above, it means you have successfully imported a module! If you’re hitting issues, please ask for help before moving on.
 

--- a/content/english/python-pixel/colors_and_pixels/open-image.md
+++ b/content/english/python-pixel/colors_and_pixels/open-image.md
@@ -10,7 +10,7 @@ Let’s first find some images to open. Find an image of your choice and downloa
 
 For example, to upload the cat.jpg file:
 
-![alt text](../../media/upload_file.png "image showing how to upload a file")
+<img src="../../media/upload_file.png" alt="Image showing how to upload a file" width="60%">
 
 You should see the JPG file on the left side once you’ve uploaded it. Note that your image may have a different extension. 
 
@@ -27,4 +27,4 @@ If you are using a different image, then make sure you put the name of the file 
 
 Hit run and see your image appear! My image looks like this:
 
-<img src="../../media/cat.png" alt="cat" width=50%>
+<img src="../../media/cat.png" alt="Cat image example" width="50%">

--- a/content/english/python-pixel/colors_and_pixels/open-image.md
+++ b/content/english/python-pixel/colors_and_pixels/open-image.md
@@ -1,6 +1,6 @@
 ---
 title: "Open an image"
-date: 2020-02-10T13:24:17-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 weight: 2
 --- 

--- a/content/english/python-pixel/colors_and_pixels/pixel-on-image.md
+++ b/content/english/python-pixel/colors_and_pixels/pixel-on-image.md
@@ -13,10 +13,10 @@ Pixels are a small area of color on a display screen. Images are formed by pixel
 <div style="width:80%;padding-left:20%;">
     <table>
         <td>
-            <img src="../../media/nuvi.png" width=100%>
+            <img src="../../media/nuvi.png" alt="Nuvi character" width="100%">
         </td>
         <td>
-            <img src="../../media/pixel-nuvi.png" width=100%>
+            <img src="../../media/pixel-nuvi.png" alt="Nuvi character shown as pixels" width="100%">
         </td>
     </table>
 </div>
@@ -45,7 +45,7 @@ img.save('pil_grey.png')
 ```
 The variable `img` stores the PNG image that looks like this: 
 
-![alt text](../../media/grey.png "Image showing pixels first example")
+<img src="../../media/grey.png" alt="Image showing pixels first example" width="40%">
 
 ```python
 # Remember to import Image
@@ -55,7 +55,7 @@ img.save('pil_black.png')
 ```
 Here, specifying `black` as the RGB color creates and stores the PNG image that looks like this:
 
-![alt text](../../media/black.png "Image showing pixels second example")
+<img src="../../media/black.png" alt="Image showing pixels second example" width="40%">
 
 ## Changing a pixel in an image 
 
@@ -75,5 +75,5 @@ img.save('pil_black-dot.png')
 
 After creating a 200x100 yellow image, the `putpixel` function puts a tiny small dot in the middle of this yellow block. This is one small pixel - in fact, it's so small you may have to expand the image to actually see it!
 
-![alt text](../../media/black-dot.png "image showing pixels third example")
+<img src="../../media/black-dot.png" alt="Image showing pixels third example" width="40%">
 


### PR DESCRIPTION
## Summary

Fixes oversized images throughout the Python Pixels workshop that made content hard to read on screen. Applies to both English and Brazilian Portuguese.

## Problem

- Markdown images (`![alt](url)`) rendered at full original size with no width constraints — color theory diagrams and code output screenshots filled the entire content area
- Some HTML `<img>` tags used `width=100%` in full-width containers, making Replit screenshots unnecessarily huge
- Width attributes were unquoted (`width=50%` instead of `width="50%"`) — invalid HTML
- Many images lacked alt text — accessibility gap for screen readers

## Changes (28 files across 2 languages)

### Image sizing
- **Color theory diagram** (colors.svg.png): unconstrained → 50%
- **Color samples** (black/white/grey): unconstrained → 40%
- **Code output screenshots**: unconstrained → 60%
- **Replit UI screenshot table**: 100% container → 70% container
- **UI screenshots** (upload, module install): unconstrained → 60%

### Standards applied
- All markdown images converted to `<img>` tags with explicit width
- All width attributes properly quoted
- Descriptive alt text added in English and Portuguese
- Hugo build verified clean

## Languages affected
- [x] English (14 files)
- [x] Brazilian Portuguese (14 files)
- No other languages have this workshop

## Testing
- [x] Hugo build passes
- [x] All image files verified to exist at referenced paths
- [x] Both language versions updated identically
- [x] No case-sensitivity issues found
