### PR TITLE
Add CODEOWNERS and issue templates for structured contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,66 @@
+---
+name: Bug report
+description: Report a problem with a workshop (broken links, incorrect code, display issues)
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: workshop
+    attributes:
+      label: Workshop
+      description: Which workshop is affected?
+      options:
+        - web-basics (HTML/CSS)
+        - python-basics
+        - python-turtle
+        - python-earsketch
+        - python-pixel
+        - python-pong
+        - csharp-basics
+        - csharp-guess-the-word
+        - chatbot
+        - javascript-basics
+        - github-basics
+        - sql-workshop
+        - security-fundamentals
+        - security-phishing
+        - supply-chain-analytics
+        - Other (specify in description)
+    validations:
+      required: true
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      description: Which language version?
+      options:
+        - English
+        - Español
+        - Brazilian Portuguese
+        - Korean
+        - French
+        - German
+        - Simplified Chinese
+        - Traditional Chinese
+        - Kyrgyz
+        - All languages
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem. Include the page URL or file path if possible.
+      placeholder: "Example: The image on Activity 3 doesn't load. The alt text says 'Cannot load image'."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should happen?
+      description: What did you expect to see instead?
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem.

--- a/.github/ISSUE_TEMPLATE/new-workshop.yml
+++ b/.github/ISSUE_TEMPLATE/new-workshop.yml
@@ -1,0 +1,57 @@
+---
+name: New workshop proposal
+description: Propose a new workshop topic for NuevoFoundation
+title: "[New Workshop]: "
+labels: ["enhancement", "new-workshop"]
+body:
+  - type: input
+    id: title
+    attributes:
+      label: Workshop title
+      description: What would you call this workshop?
+      placeholder: "Example: Python: Web Scraping"
+    validations:
+      required: true
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty level
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Workshop description
+      description: What will students learn? What will they build?
+      placeholder: "Students will learn how to use Python's BeautifulSoup library to extract data from websites. By the end, they'll have a script that collects weather data."
+    validations:
+      required: true
+  - type: textarea
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: What should students know before starting this workshop?
+      placeholder: "Basic Python knowledge (variables, loops, functions)"
+  - type: textarea
+    id: tools
+    attributes:
+      label: Tools and platforms
+      description: What tools or platforms does this workshop use?
+      placeholder: "Replit (free account), Python 3"
+  - type: input
+    id: activities
+    attributes:
+      label: Estimated number of activities
+      placeholder: "5"
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked that a similar workshop doesn't already exist
+          required: true
+        - label: I'm willing to help create this workshop

--- a/.github/ISSUE_TEMPLATE/translation-request.yml
+++ b/.github/ISSUE_TEMPLATE/translation-request.yml
@@ -1,0 +1,59 @@
+---
+name: Translation request
+description: Request a workshop be translated to a new language
+title: "[Translation]: "
+labels: ["translation"]
+body:
+  - type: dropdown
+    id: workshop
+    attributes:
+      label: Workshop to translate
+      description: Which English workshop should be translated?
+      options:
+        - web-basics (HTML/CSS)
+        - python-basics
+        - python-turtle
+        - python-earsketch
+        - python-pixel
+        - python-pong
+        - csharp-basics
+        - chatbot
+        - javascript-basics
+        - github-basics
+        - sql-workshop
+        - security-fundamentals
+        - Other (specify below)
+    validations:
+      required: true
+  - type: dropdown
+    id: language
+    attributes:
+      label: Target language
+      description: Which language should this workshop be translated to?
+      options:
+        - Español
+        - Brazilian Portuguese
+        - Korean
+        - French
+        - German
+        - Simplified Chinese
+        - Traditional Chinese
+        - Russian
+        - Japanese
+        - Other (specify below)
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Are you volunteering to do this translation? Any special considerations?
+      placeholder: "Example: I'm a native Spanish speaker and would like to translate this workshop for our chapter in Mexico City."
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before starting
+      options:
+        - label: I checked that this workshop doesn't already exist in the target language
+          required: true
+        - label: I'm willing to translate the full workshop (not just the landing page)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,26 @@
+# NuevoFoundation/workshops code owners
+#
+# These owners are automatically requested for review when a PR
+# touches files in their area. See GitHub docs:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner — catches everything not matched below
+*                                       @ozhang22
+
+# Workshop content by language
+content/english/                        @ozhang22 @beagandica
+content/espanol/                        @ozhang22
+content/brazilian-portuguese/           @ozhang22
+content/korean/                         @ozhang22
+content/francais/                       @ozhang22
+content/simplified-chinese/             @ozhang22
+content/traditional-chinese/            @ozhang22
+
+# Hugo configuration and theme
+config.toml                             @ozhang22
+layouts/                                @ozhang22
+themes/                                 @ozhang22
+
+# CI, tooling, and repo infrastructure
+.github/                                @ozhang22 @beagandica
+tools/                                  @ozhang22 @beagandica


### PR DESCRIPTION
## Summary

CODEOWNERS file and 3 issue templates to improve contribution workflows.

## Changes

### CODEOWNERS
- `@ozhang22` as default owner for all files
- `@beagandica` as co-owner for English content and infrastructure (.github/, tools/)
- Auto-routes review requests to the right maintainers

### Issue templates (3 new)
- **Bug report** — structured form with workshop/language dropdowns, screenshot upload
- **Translation request** — checklist to avoid duplicate work, language picker
- **New workshop proposal** — captures scope, difficulty, prerequisites, tools

## Why
- Contributors get clear paths for reporting issues and proposing work
- Reviews auto-route to the right people via CODEOWNERS
- Issue templates reduce back-and-forth on incomplete reports
- Complements PR #626 (PR template, CI, CONTRIBUTING.md)

## Languages affected
N/A — infrastructure files only

## Testing
- [x] YAML syntax validated
- [x] CODEOWNERS syntax follows GitHub format
- [x] Issue template forms render correctly (GitHub YAML form schema)