### PR TITLE
Add 5 missing contributor guidelines pages (Closes #7, #10, #11, #12, #13)

### DIFF
--- a/content/english/guidelines/_index.md
+++ b/content/english/guidelines/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Workshop Contributor Guidelines"
 description: "We welcome contributions. Great ways to contribute include trying things out, filing bugs, creating, and adding new workshops."
-date: 2019-07-22T14:08:32-07:00
+date: 2026-04-25T00:00:00-07:00
 draft: false
 hidden: false
 ---
@@ -19,6 +19,14 @@ Looking to contribute more? Take a look at our <a target="_blank" href="https://
 Interested in creating or modifying workshops? Follow the "Start here" guides above, then the following:
   - [Formatting](formatting)
   - [New Workshop Guidelines](new-workshops)
+  - [Images and GIFs](images-and-gifs)
+  - [Navigation](navigation)
+  - [Code and Interactivity](code-and-interactivity)
+  - [Tags and Metadata](tags-and-metadata)
+
+## For translators
+Want to help make workshops available in more languages?
+  - [Translation Volunteer Guide](translation-volunteer)
 
 ## For web developers
 Interested in improving this website? Follow the "Start here" guides above, then the following:

--- a/content/english/guidelines/_index.md
+++ b/content/english/guidelines/_index.md
@@ -18,15 +18,15 @@ Looking to contribute more? Take a look at our <a target="_blank" href="https://
 ## For content creators
 Interested in creating or modifying workshops? Follow the "Start here" guides above, then the following:
   - [Formatting](formatting)
-  - [New Workshop Guidelines](new-workshops)
+  - [Creating a new workshop](new-workshops)
   - [Images and GIFs](images-and-gifs)
   - [Navigation](navigation)
-  - [Code and Interactivity](code-and-interactivity)
-  - [Tags and Metadata](tags-and-metadata)
+  - [Code and interactivity](code-and-interactivity)
+  - [Tags and metadata](tags-and-metadata)
 
 ## For translators
 Want to help make workshops available in more languages?
-  - [Translation Volunteer Guide](translation-volunteer)
+  - [Translation volunteer guide](translation-volunteer)
 
 ## For web developers
 Interested in improving this website? Follow the "Start here" guides above, then the following:

--- a/content/english/guidelines/code-and-interactivity.md
+++ b/content/english/guidelines/code-and-interactivity.md
@@ -25,7 +25,7 @@ For activities where students write and run code, embed an interactive editor. H
 
 ### Replit
 
-Best for Python, JavaScript, and general-purpose programming.
+Best for Python, JavaScript, and general-purpose programming. Use the `replit.com` domain for new embeds (older workshops may use `repl.it`, which still redirects).
 
 ```html
 <a class="my-2 mx-4 btn btn-info" href="https://replit.com/@nuevofoundation/python-basics" target="_blank">Launch Replit</a>
@@ -45,7 +45,7 @@ Best for Python turtle graphics and simple Python programs.
 <iframe src="https://trinket.io/embed/python/abc123" width="100%" height="600" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen></iframe>
 ```
 
-### DotNetFiddle
+### .NET Fiddle
 
 Best for C# programs.
 
@@ -55,15 +55,15 @@ Best for C# programs.
 
 ### CodePen
 
-Best for HTML/CSS/JavaScript web projects.
+Best for HTML/CSS/JavaScript web projects. In this repo, CodePen is typically used as a link button rather than an inline embed:
 
 ```html
-<iframe height="400" width="100%" src="https://codepen.io/user/embed/abc123?default-tab=html%2Cresult" frameborder="no" loading="lazy" allowfullscreen></iframe>
+<a class="my-2 mx-4 btn btn-info" href="https://codepen.io/Sunny-Dee/pen/exxyYL" target="_blank">Try it yourself!</a>
 ```
 
 ## Interactive HTML elements
 
-For custom interactivity (quizzes, drag-and-drop, buttons), use the `rawhtml` shortcode:
+For custom interactivity (quizzes, drag-and-drop, buttons), you can use raw HTML directly in markdown (Hugo's `unsafe` rendering is enabled for this site). Alternatively, use the `rawhtml` shortcode:
 
 ```
 {{</* rawhtml */>}}
@@ -95,3 +95,8 @@ Remember to use parentheses when calling a function!
 - Set `height="600"` as a starting point for embedded editors and adjust as needed
 - Add a fallback link below iframes in case embedding is blocked: "Can't see the editor? [Open it in a new tab](link)"
 - Keep code examples short and focused. If an example exceeds 20 lines, consider splitting it into steps.
+
+## See also
+
+- [Formatting](../formatting) — Visual shortcodes (alerts, buttons, notices, expand)
+- [Tags and Metadata](../tags-and-metadata) — Frontmatter fields for all page types

--- a/content/english/guidelines/code-and-interactivity.md
+++ b/content/english/guidelines/code-and-interactivity.md
@@ -34,8 +34,10 @@ Best for Python, JavaScript, and general-purpose programming. Use the `replit.co
 Or embed directly:
 
 ```html
-<iframe height="600" width="100%" src="https://replit.com/@nuevofoundation/python-basics?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true"></iframe>
+<iframe height="600" width="100%" src="https://replit.com/@nuevofoundation/python-basics" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true"></iframe>
 ```
+
+Note: older workshops include `?lite=true` in Replit URLs. This parameter is no longer active and can be omitted from new embeds.
 
 ### Trinket
 
@@ -83,9 +85,9 @@ A good activity follows this pattern:
 4. **Hint** using a notice shortcode:
 
 ```
-{{</* notice tip */>}}
+{{% notice tip %}}
 Remember to use parentheses when calling a function!
-{{</* /notice */>}}
+{{% /notice %}}
 ```
 
 ## Tips

--- a/content/english/guidelines/code-and-interactivity.md
+++ b/content/english/guidelines/code-and-interactivity.md
@@ -1,0 +1,97 @@
+---
+title: "Code and interactivity"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 9
+---
+
+Workshops are interactive. Students should be able to run code, see results, and experiment. This guide covers how to embed code editors and interactive elements.
+
+## Inline code blocks
+
+For code examples that students read but don't run directly, use standard markdown fenced code blocks with language hints:
+
+````markdown
+```python
+print("Hello, World!")
+```
+````
+
+Supported languages include `python`, `html`, `css`, `javascript`, `csharp`, `java`, `sql`, `bash`, and many more.
+
+## Embedded code editors
+
+For activities where students write and run code, embed an interactive editor. Here are the platforms we use:
+
+### Replit
+
+Best for Python, JavaScript, and general-purpose programming.
+
+```html
+<a class="my-2 mx-4 btn btn-info" href="https://replit.com/@nuevofoundation/python-basics" target="_blank">Launch Replit</a>
+```
+
+Or embed directly:
+
+```html
+<iframe height="600" width="100%" src="https://replit.com/@nuevofoundation/python-basics?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true"></iframe>
+```
+
+### Trinket
+
+Best for Python turtle graphics and simple Python programs.
+
+```html
+<iframe src="https://trinket.io/embed/python/abc123" width="100%" height="600" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen></iframe>
+```
+
+### DotNetFiddle
+
+Best for C# programs.
+
+```html
+<iframe width="100%" height="475" src="https://dotnetfiddle.net/Widget/abc123" frameborder="0"></iframe>
+```
+
+### CodePen
+
+Best for HTML/CSS/JavaScript web projects.
+
+```html
+<iframe height="400" width="100%" src="https://codepen.io/user/embed/abc123?default-tab=html%2Cresult" frameborder="no" loading="lazy" allowfullscreen></iframe>
+```
+
+## Interactive HTML elements
+
+For custom interactivity (quizzes, drag-and-drop, buttons), use the `rawhtml` shortcode:
+
+```
+{{</* rawhtml */>}}
+<button onclick="alert('Correct!')">Click me</button>
+{{</* /rawhtml */>}}
+```
+
+This allows arbitrary HTML, CSS, and JavaScript inside a workshop page.
+
+## Challenge structure
+
+A good activity follows this pattern:
+
+1. **Explain** the concept with a brief description
+2. **Show** an example with a code block
+3. **Challenge** the student to write their own code
+4. **Hint** using a notice shortcode:
+
+```
+{{</* notice tip */>}}
+Remember to use parentheses when calling a function!
+{{</* /notice */>}}
+```
+
+## Tips
+
+- Always provide a **working starting point** so students aren't staring at a blank editor
+- Test all embedded links before submitting. Replit and Trinket links can expire.
+- Set `height="600"` as a starting point for embedded editors and adjust as needed
+- Add a fallback link below iframes in case embedding is blocked: "Can't see the editor? [Open it in a new tab](link)"
+- Keep code examples short and focused. If an example exceeds 20 lines, consider splitting it into steps.

--- a/content/english/guidelines/images-and-gifs.md
+++ b/content/english/guidelines/images-and-gifs.md
@@ -1,0 +1,115 @@
+---
+title: "Images and GIFs"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 7
+---
+
+Images make workshops more engaging for young learners. Follow these guidelines to ensure images are accessible, properly sized, and work across all platforms.
+
+## Image sizing
+
+Never leave images without width constraints. Without a `width` attribute, images render at their original size, which is often too large for the content area.
+
+| Image type | Target width | Example |
+|-----------|-------------|---------|
+| Full UI screenshots (Replit, IDE) | 60% | Replit upload dialog |
+| Code output / terminal | 70% | dotnetfiddle results |
+| Concept diagrams | 50% | Color theory, data structures |
+| Photo examples | 40-50% | python-pixel cat images |
+| Small icons / badges | 15-25% | Tables, small diagrams |
+| Decorative art | 20-30% | Character illustrations |
+| Hero images | 100% | Landing page `_index.md` only |
+
+**Use percentages, not pixels.** Percentage widths are responsive and scale on mobile and tablet. Pixel widths can overflow on smaller screens.
+
+```markdown
+<!-- Good: responsive -->
+<img src="../img/screenshot.png" alt="Replit code editor" width="60%">
+
+<!-- Avoid: fixed pixel width -->
+<img src="../img/screenshot.png" alt="Replit code editor" width="900px">
+```
+
+## Adding images
+
+### Method 1: Markdown syntax
+
+```markdown
+![Description of the image](../img/filename.png)
+```
+
+### Method 2: HTML img tag (when you need width control)
+
+```html
+<img src="../img/filename.png" alt="Description of the image" width="50%">
+```
+
+### Method 3: Hugo figure shortcode
+
+```
+{{</* figure src="../img/filename.png" alt="Description" width="50%" */>}}
+```
+
+The `figure` shortcode provides theme-consistent rendering and is the preferred approach for new content.
+
+## Accessibility (alt text)
+
+Every image **must** have descriptive alt text. This is non-negotiable.
+
+| Do | Don't |
+|----|-------|
+| `alt="Replit code editor showing a Python hello world program"` | `alt="screenshot"` |
+| `alt="RGB color diagram with red, green, and blue circles overlapping"` | `alt="image"` |
+| `alt=""` (for purely decorative images like dividers) | `alt="Cannot load image"` |
+
+For translated workshops, alt text must be in the page's language:
+- English: `alt="A friendly chatbot welcoming users"`
+- Portuguese: `alt="Um chatbot amigavel dando boas-vindas aos usuarios"`
+- Korean: `alt="사용자를 환영하는 친근한 챗봇"`
+
+## File naming
+
+- Use **lowercase** file extensions: `.png`, `.jpg`, `.gif` (not `.PNG`, `.JPG`)
+- Use **descriptive names**: `replit-upload-dialog.png` (not `img1.png`)
+- Use **hyphens** for word separation: `color-theory-diagram.png` (not `color_theory_diagram.png`)
+- Keep names short but meaningful
+
+## Image location
+
+Store images in an `img/` or `media/` directory inside the workshop folder:
+
+```
+content/english/my-workshop/
+  _index.md
+  activity-1.md
+  img/              <-- images here
+    screenshot.png
+    diagram.png
+```
+
+Reference them with relative paths from the page: `../img/screenshot.png`
+
+{{< notice warning >}}
+Hugo resolves relative paths from the **page URL**, not the filesystem location. For child pages at `/workshop/section/activity/`, the path `../img/file.png` resolves to `/workshop/img/file.png`. This is the correct pattern.
+{{< /notice >}}
+
+## GIFs
+
+GIFs are great for showing short interactions (clicking buttons, dragging elements). Keep them:
+
+- **Short**: 5-15 seconds max
+- **Small**: Under 2MB if possible (large GIFs slow page load)
+- **Clear**: Use a reasonable frame rate. Screen recordings at 10-15fps work well.
+- **Accessible**: Add alt text describing what the GIF shows
+
+Consider using a static image with a caption instead of a GIF if the animation isn't essential to understanding.
+
+## Screenshots
+
+When taking screenshots for workshops:
+
+1. **Crop tightly** to the relevant area
+2. **Use a clean environment** (no personal bookmarks, notifications, etc.)
+3. **Consistent sizing** within a workshop (don't mix 1080p and 4K screenshots)
+4. **Highlight the relevant area** if the screenshot includes a lot of UI

--- a/content/english/guidelines/images-and-gifs.md
+++ b/content/english/guidelines/images-and-gifs.md
@@ -25,10 +25,10 @@ Never leave images without width constraints. Without a `width` attribute, image
 
 ```markdown
 <!-- Good: responsive -->
-<img src="../img/screenshot.png" alt="Replit code editor" width="60%">
+<img src="../media/screenshot.png" alt="Replit code editor" width="60%">
 
 <!-- Avoid: fixed pixel width -->
-<img src="../img/screenshot.png" alt="Replit code editor" width="900px">
+<img src="../media/screenshot.png" alt="Replit code editor" width="900px">
 ```
 
 ## Adding images
@@ -36,22 +36,22 @@ Never leave images without width constraints. Without a `width` attribute, image
 ### Method 1: Markdown syntax
 
 ```markdown
-![Description of the image](../img/filename.png)
+![Description of the image](../media/filename.png)
 ```
 
 ### Method 2: HTML img tag (when you need width control)
 
 ```html
-<img src="../img/filename.png" alt="Description of the image" width="50%">
+<img src="../media/filename.png" alt="Description of the image" width="50%">
 ```
 
 ### Method 3: Hugo figure shortcode
 
 ```
-{{</* figure src="../img/filename.png" alt="Description" width="50%" */>}}
+{{</* figure src="../media/filename.png" alt="Description" width="50%" */>}}
 ```
 
-The `figure` shortcode wraps images in a `<figure>` element. Note: most existing workshops use the markdown or HTML approaches above.
+The `figure` shortcode wraps images in a `<figure>` element. Note: most existing workshops use the markdown or HTML approaches above. Older workshops may use `img/` instead of `media/` — both work identically.
 
 ## Accessibility (alt text)
 
@@ -77,22 +77,22 @@ For translated workshops, alt text must be in the page's language:
 
 ## Image location
 
-Store images in an `img/` or `media/` directory inside the workshop folder:
+New workshops should use a `media/` directory (the scaffold script generates this automatically). Some older workshops use `img/` instead — both work the same way in Hugo.
 
 ```
 content/english/my-workshop/
   _index.md
   activity-1.md
-  img/              <-- images here
+  media/             <-- images here
     screenshot.png
     diagram.png
 ```
 
-Reference them with relative paths from the page: `../img/screenshot.png`
+Reference images with relative paths from the page. In `_index.md`, use `media/image.png`. In activity pages and answer keys, use `../media/image.png` (they render one level deeper in Hugo).
 
-{{< notice warning >}}
-Hugo resolves relative paths from the **page URL**, not the filesystem location. For child pages at `/workshop/section/activity/`, the path `../img/file.png` resolves to `/workshop/img/file.png`. This is the correct pattern.
-{{< /notice >}}
+{{% notice warning %}}
+Hugo resolves relative paths from the **page URL**, not the filesystem location. For child pages at `/workshop/section/activity/`, the path `../media/file.png` resolves to `/workshop/media/file.png`. This is the correct pattern. Do not "fix" these `../` paths — they are intentional.
+{{% /notice %}}
 
 ## GIFs
 

--- a/content/english/guidelines/images-and-gifs.md
+++ b/content/english/guidelines/images-and-gifs.md
@@ -51,7 +51,7 @@ Never leave images without width constraints. Without a `width` attribute, image
 {{</* figure src="../img/filename.png" alt="Description" width="50%" */>}}
 ```
 
-The `figure` shortcode provides theme-consistent rendering and is the preferred approach for new content.
+The `figure` shortcode wraps images in a `<figure>` element. Note: most existing workshops use the markdown or HTML approaches above.
 
 ## Accessibility (alt text)
 

--- a/content/english/guidelines/navigation.md
+++ b/content/english/guidelines/navigation.md
@@ -88,13 +88,13 @@ Draft pages only appear when running `hugo server -D` (the `-D` flag includes dr
 To show a list of child pages on a landing page, use the `children` shortcode inside a collapsible details element:
 
 ```html
-<details close>
+<details>
 <summary>Table of Contents</summary>
 {{% children /%}}
 </details>
 ```
 
-This renders a clean, collapsible table of contents that students can expand when ready.
+This renders a clean, collapsible table of contents that students can expand when ready. Some existing workshops use `<details open>` for an expanded default.
 
 ## Workshop landing page template
 

--- a/content/english/guidelines/navigation.md
+++ b/content/english/guidelines/navigation.md
@@ -1,0 +1,122 @@
+---
+title: "Navigation"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 8
+---
+
+Hugo uses frontmatter metadata in each markdown file to control how pages appear in the site navigation. This guide covers the key settings.
+
+## Page ordering with weight
+
+The `weight` field controls the order of pages in the left sidebar and table of contents. Lower numbers appear first.
+
+```yaml
+---
+title: "Activity 1: Getting started"
+weight: 3
+---
+```
+
+**Recommended weight scheme:**
+
+| Page type | Weight | Example |
+|-----------|--------|---------|
+| `_index.md` (landing page) | 1 | Workshop intro |
+| Setup / prerequisites | 2 | Tools needed |
+| Activities | 3, 4, 5... | Activity 1, 2, 3 |
+| Answer key | 15+ | Hidden from nav |
+
+Leave gaps between activity weights if you expect to insert pages later (e.g., use 3, 5, 7 instead of 3, 4, 5).
+
+## Controlling the table of contents
+
+### Collapsed TOC (preferred)
+
+Workshops should open with a story introduction visible and the activity list collapsed:
+
+```yaml
+---
+title: "Python: Basics"
+alwaysopen: false
+---
+```
+
+With `alwaysopen: false`, the child pages appear as a collapsible tree in the sidebar. Students expand sections as they progress.
+
+### Expanded TOC
+
+For very short workshops (3 or fewer activities), you may want all sections visible:
+
+```yaml
+---
+title: "Short Workshop"
+alwaysopen: true
+---
+```
+
+## Hiding pages
+
+### Hidden pages (built but not in nav)
+
+Use `hidden: true` for pages that should exist but not appear in the sidebar navigation. Students can still access them via a direct link.
+
+```yaml
+---
+title: "Answer Key"
+hidden: true
+---
+```
+
+Common uses: answer keys, instructor notes, bonus content.
+
+### Draft pages (not built in production)
+
+Use `draft: true` for work in progress that shouldn't appear on the live site at all:
+
+```yaml
+---
+title: "Unfinished Workshop"
+draft: true
+---
+```
+
+Draft pages only appear when running `hugo server -D` (the `-D` flag includes drafts).
+
+## The children shortcode
+
+To show a list of child pages on a landing page, use the `children` shortcode inside a collapsible details element:
+
+```html
+<details close>
+<summary>Table of Contents</summary>
+{{% children /%}}
+</details>
+```
+
+This renders a clean, collapsible table of contents that students can expand when ready.
+
+## Workshop landing page template
+
+Here's a complete `_index.md` frontmatter example:
+
+```yaml
+---
+title: "Python: Basics"
+description: "Learn Python fundamentals"
+date: 2026-04-25T00:00:00-07:00
+difficulty: "Beginner"
+prereq: "None"
+draft: false
+alwaysopen: false
+icon: "fab fa-python"
+weight: 1
+---
+```
+
+## Tips
+
+- Test navigation changes locally with `hugo server -D` before submitting
+- Check that answer keys are `hidden: true` so students don't see them
+- Keep weight numbers consistent within a workshop
+- If you reorder pages, update all weights to avoid gaps or collisions

--- a/content/english/guidelines/new-workshops.md
+++ b/content/english/guidelines/new-workshops.md
@@ -1,10 +1,218 @@
 ---
-title: "New Workshop Guidelines"
-date: 2020-07-29T14:08:32-07:00
+title: "Creating a new workshop"
+date: 2026-04-26T00:00:00-07:00
 draft: false
 weight: 2
 ---
 
-This document is intended to guide you on how to create new workshops for the [Nuevo Foundation workshop project](https://github.com/nuevoFoundation/workshops).
+This guide walks you through creating a new workshop from idea to pull request. Before you begin, complete the [Getting Started](../getting-started/) setup (Git, Hugo, fork) and read the [Site Architecture](../site-architecture/) overview.
 
-Please familiarize yourself with the [Site Architecture](../site-architecture/) and the [Getting Started](../getting-started/) sections.
+## Our philosophy
+
+Nuevo Foundation workshops should feel like **guided adventures**, not textbooks. Every workshop tells a story that students follow at their own pace. The best workshops are:
+
+- **Story-driven**: students follow a character on a mission (Benji the Dog needs a website, Alex the Bee needs a honeycomb, DJ Nuvi needs a hit mixtape)
+- **Personalizable**: students can easily swap the theme to match their interests (their pet instead of Benji, their country instead of Costa Rica)
+- **Self-paced**: clear enough that students can work on their own, even when the teacher steps away
+- **Progressive**: activities build on each other, one concept at a time
+- **Fun**: encouraging tone, mascot characters, visual rewards, and celebration at the end
+
+## Learn from our best workshops
+
+Study these gold-standard workshops before building your own:
+
+### Web basics (HTML/CSS) — [content/english/web-basics/](https://github.com/NuevoFoundation/workshops/tree/master/content/english/web-basics)
+
+- **Theme**: Help Benji the Dog (displaced by Hurricane Harvey) find his forever home by building him a website
+- **Why it works**: emotional hook, YouTube video on every page, CodePen embeds for instant coding, Activity 5 lets students build their own site, deploys to real GitHub Pages
+- **Key pattern**: narrative → concept → video → reference table → hands-on exercise
+
+### Python turtle — [content/english/python-turtle/](https://github.com/NuevoFoundation/workshops/tree/master/content/english/python-turtle)
+
+- **Theme**: Help Alex the Bee build a honeycomb home using Python drawing
+- **Why it works**: 11 YouTube videos, embedded Trinket IDE, visual results (students SEE their code draw shapes), progressive complexity (line → square → hexagon → honeycomb → mandala flower)
+- **Key pattern**: story context → video → code example → interactive Trinket → challenge
+
+### EarSketch (Python and JS blocks) — [content/english/python-earsketch/](https://github.com/NuevoFoundation/workshops/tree/master/content/english/python-earsketch)
+
+- **Theme**: Help DJ Nuvi produce a hit mixtape using code
+- **Why it works**: students HEAR their code (music!), immediate audible feedback, professional tool (Georgia Tech), creative freedom in sound choices
+- **Key pattern**: music concept → code concept → build → listen → iterate
+
+## Step 1: scaffold your workshop
+
+Use the scaffold script to generate the correct directory structure and template files. Do not create workshop files manually — the scaffold ensures correct Hugo frontmatter, file naming, and directory layout.
+
+**Requirement:** Python 3.7 or later. Verify with `python --version` (or `python3 --version` on macOS/Linux).
+
+Run this from the root of the `workshops` repository:
+
+```bash
+python tools/new-workshop.py --name "my-workshop" --title "My Workshop"
+```
+
+Use `--dry-run` first to preview what would be created without writing any files:
+
+```bash
+python tools/new-workshop.py --name "my-workshop" --title "My Workshop" --dry-run
+```
+
+This generates the standard starter structure:
+
+```
+content/english/my-workshop/
+├── _index.md          ← Landing page (intro, prerequisites, TOC)
+├── activity-1.md      ← First activity
+├── activity-2.md      ← Second activity
+├── activity-3.md      ← Third activity
+├── answer-key.md      ← Answer key (hidden from navigation)
+└── media/
+    └── .gitkeep       ← Folder for screenshots and images
+```
+
+### Scaffold options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--name` | (required) | Directory name in kebab-case (e.g. `python-web-scraping`) |
+| `--title` | (required) | Display title (e.g. `"Python: Web Scraping"`) |
+| `--activities` or `-n` | 3 | Number of activity files to generate (1 to 25) |
+| `--difficulty` | Beginner | `Beginner`, `Intermediate`, or `Advanced` |
+| `--description` | (empty) | Short description for the landing page |
+| `--prereq` | `"None"` | Prerequisite workshop name |
+| `--icon` | `fas fa-code` | Font Awesome icon class |
+| `--language` or `-l` | english | Language folder (e.g. `espanol`, `korean`) |
+| `--no-answer-key` | (off) | Skip generating the answer key file |
+| `--dry-run` | (off) | Preview without writing files |
+
+### Example: intermediate workshop with 5 activities
+
+```bash
+python tools/new-workshop.py \
+  --name "python-web-scraping" \
+  --title "Python: Web Scraping" \
+  --activities 5 \
+  --difficulty Intermediate \
+  --prereq "Python Basics" \
+  --description "Learn to scrape data from websites using Python"
+```
+
+## Step 2: fill in your content
+
+Open the generated files and replace the placeholder text:
+
+1. **`_index.md`** (landing page): Write the introduction. Set up your story, explain what students will learn, and list prerequisites. The `{{% children /%}}` shortcode at the bottom auto-generates the table of contents — leave it in place.
+2. **`activity-N.md`** files: Write step-by-step instructions for each activity. Replace placeholder titles with descriptive names (e.g. `"Activity 1: Drawing shapes"`). Include a challenge at the end of each activity.
+3. **`answer-key.md`**: Add solutions for every activity challenge. This file has `hidden: true` in its frontmatter so it won't appear in navigation.
+4. **`media/`**: Add screenshots, diagrams, or images. Use `media/image-name.png` in `_index.md` and `../media/image-name.png` in activity pages (activity pages render one level deeper in Hugo, so they need `../` to reach the media folder).
+
+For formatting help, see the [Formatting](../formatting/) and [Code and interactivity](../code-and-interactivity/) guides.
+
+## Step 3: preview locally
+
+From the `workshops` directory:
+
+```bash
+hugo server -D
+```
+
+Open **http://localhost:1313/** and navigate to your workshop. Click through every activity to check that content renders correctly, images load, and navigation works.
+
+## Step 4: open a pull request
+
+```bash
+git checkout -b workshop/my-workshop
+git add content/english/my-workshop/
+git commit -m "Add my-workshop workshop"
+git push --set-upstream origin workshop/my-workshop
+```
+
+Then open a pull request from your fork to the main repo.
+
+## Workshop quality checklist
+
+Use this checklist before submitting your PR. Reviewers will check the same items.
+
+### Landing page (`_index.md`)
+
+- [ ] Metadata block is complete (title, description, date, prereq, difficulty, draft, icon)
+- [ ] Story introduction sets up the adventure theme and character
+- [ ] Prerequisites are clearly listed
+- [ ] "What you'll learn" section with clear learning outcomes
+- [ ] Theme is personalizable so students can swap names, characters, or topics
+- [ ] `{{% children /%}}` shortcode present at bottom for auto-generated table of contents
+
+### Activities (`activity-N.md`)
+
+- [ ] One concept per activity (no concept overload)
+- [ ] Activities build on each other (progressive difficulty)
+- [ ] Step-by-step instructions clear enough for a student to follow without a teacher
+- [ ] Code snippets are syntactically correct and actually runnable
+- [ ] Images throughout to help visual learners
+- [ ] All images have descriptive alt text (see [Images and GIFs](../images-and-gifs/))
+- [ ] Interactive coding environment embedded when possible (Replit, Trinket, CodePen — see [Code and interactivity](../code-and-interactivity/))
+- [ ] Encouraging tone ("Great job!", "You're doing amazing!")
+- [ ] Use `notice tip` shortcodes for best practices and `notice warning` for common pitfalls
+- [ ] Weight values create correct page ordering in sidebar (see [Navigation](../navigation/))
+
+### Answer key (`answer-key.md`)
+
+- [ ] Metadata has `hidden: true` so students don't see it in navigation
+- [ ] Contains answers for ALL activity challenges
+- [ ] Complex activities have step-by-step solutions, not just final code
+- [ ] Optional/bonus challenges are also covered
+- [ ] Teacher notes where helpful ("This curriculum allows students to be creative. The below is just an example.")
+
+### Media and assets
+
+- [ ] All referenced images exist in the media folder
+- [ ] File names match references exactly (case-sensitive — `Cafe.png` is NOT `cafe.png` on Linux)
+- [ ] No unreferenced files sitting unused in media
+- [ ] Images are optimized (not unnecessarily large)
+- [ ] Videos hosted on YouTube, not committed to the repo as MP4 files
+
+### Writing and language
+
+- [ ] No typos or grammar errors
+- [ ] Technical terms are accurate and jargon is explained the first time it appears
+- [ ] Warm, encouraging tone throughout
+- [ ] Instructions are self-contained so a student can learn independently
+- [ ] Code blocks have language tags (` ```python `, ` ```html `, etc.)
+- [ ] File ends with a newline
+
+### Hugo and build
+
+- [ ] `hugo server -D` builds without errors
+- [ ] No `draft: true` on published content
+- [ ] Frontmatter YAML is valid (no duplicate keys, correct indentation)
+- [ ] All pages render correctly in the browser
+
+## PR review checklist (for reviewers)
+
+When reviewing a workshop PR:
+
+1. **Does it actually run?** Follow the instructions yourself. Can a student get working code?
+2. **Answer key complete?** Map every activity's challenge to its answer
+3. **Images load?** Check for case-sensitivity issues
+4. **Language quality?** Read for typos, grammar, and accuracy
+5. **Self-paced friendly?** Could a student complete this without a teacher?
+6. **Fun factor?** Is the theme engaging? Can students personalize it?
+7. **Accessibility?** Descriptive alt text on all images, clear instructions
+8. **Progressive difficulty?** Activities build on each other, one concept at a time
+9. **Hugo build clean?** Run `hugo server -D` and check for warnings
+10. **Walk through it yourself.** Complete the workshop as a student would, start to finish
+
+{{% notice info %}}
+The Hugo theme automatically adds a Nuvi "You did it! Workshop complete" celebration to the last page of every workshop. You do not need to create a separate conclusion file. If your workshop has a special story ending, you can optionally add a `conclusion.md` page.
+{{% /notice %}}
+
+## Resources
+
+- [Getting started](../getting-started/) — Git, Hugo, and fork setup
+- [How the site is built](../site-architecture/) — understand the Hugo directory structure
+- [Formatting](../formatting/) — markdown syntax and shortcodes
+- [Images and GIFs](../images-and-gifs/) — sizing, alt text, file naming
+- [Navigation](../navigation/) — frontmatter fields for page ordering
+- [Code and interactivity](../code-and-interactivity/) — embedding Replit, Trinket, CodePen
+- [Tags and metadata](../tags-and-metadata/) — complete frontmatter reference
+- [Translation volunteer guide](../translation-volunteer/) — translating workshops to other languages

--- a/content/english/guidelines/tags-and-metadata.md
+++ b/content/english/guidelines/tags-and-metadata.md
@@ -56,20 +56,20 @@ weight: 1
 
 ## Common icons
 
-The homepage displays an icon for each workshop. Use [Font Awesome](https://fontawesome.com/icons) classes:
+The homepage displays an icon for each workshop. Use [Font Awesome](https://fontawesome.com/icons) classes in the `icon` frontmatter field:
 
-| Icon | Class | Good for |
-|------|-------|----------|
-| {{< icon name="fab fa-python" >}} | `fab fa-python` | Python workshops |
-| {{< icon name="fab fa-html5" >}} | `fab fa-html5` | HTML/web workshops |
-| {{< icon name="fab fa-js" >}} | `fab fa-js` | JavaScript workshops |
-| {{< icon name="fas fa-laptop-code" >}} | `fas fa-laptop-code` | General coding |
-| {{< icon name="fas fa-microchip" >}} | `fas fa-microchip` | Hardware / Arduino |
-| {{< icon name="fas fa-shield-alt" >}} | `fas fa-shield-alt` | Security workshops |
-| {{< icon name="fas fa-database" >}} | `fas fa-database` | SQL / data workshops |
-| {{< icon name="fas fa-code" >}} | `fas fa-code` | General (default) |
-| {{< icon name="fas fa-gamepad" >}} | `fas fa-gamepad` | Game workshops |
-| {{< icon name="fas fa-music" >}} | `fas fa-music` | Music / audio |
+| Class | Good for |
+|-------|----------|
+| `fab fa-python` | Python workshops |
+| `fab fa-html5` | HTML/web workshops |
+| `fab fa-js` | JavaScript workshops |
+| `fas fa-laptop-code` | General coding |
+| `fas fa-microchip` | Hardware / Arduino |
+| `fas fa-shield-alt` | Security workshops |
+| `fas fa-database` | SQL / data workshops |
+| `fas fa-code` | General (default) |
+| `fas fa-gamepad` | Game workshops |
+| `fas fa-music` | Music / audio |
 
 ## Activity page fields
 

--- a/content/english/guidelines/tags-and-metadata.md
+++ b/content/english/guidelines/tags-and-metadata.md
@@ -1,0 +1,112 @@
+---
+title: "Tags and metadata"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 10
+---
+
+Every workshop page uses YAML frontmatter to control how it appears on the site. This guide explains each field and when to use it.
+
+## Required frontmatter
+
+Every markdown file needs at minimum:
+
+```yaml
+---
+title: "Page Title"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+---
+```
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `title` | Display title in nav and page header | `"Python: Basics"` |
+| `date` | Last update date (shown on site) | `2026-04-25T00:00:00-07:00` |
+| `draft` | `false` for published, `true` for work-in-progress | `false` |
+
+## Workshop landing page fields
+
+The `_index.md` file for a workshop supports additional fields:
+
+```yaml
+---
+title: "Python: Basics"
+description: "Learn Python fundamentals including variables, loops, and functions"
+date: 2026-04-25T00:00:00-07:00
+difficulty: "Beginner"
+prereq: "None"
+draft: false
+hidden: false
+alwaysopen: false
+icon: "fab fa-python"
+weight: 1
+---
+```
+
+| Field | Purpose | Values |
+|-------|---------|--------|
+| `description` | Short summary shown in listings | Free text |
+| `difficulty` | Skill level | `Beginner`, `Intermediate`, `Advanced` |
+| `prereq` | Prerequisites | `"None"` or workshop name |
+| `hidden` | Hide from navigation | `true` / `false` |
+| `alwaysopen` | TOC expand behavior | `false` (preferred) |
+| `icon` | Font Awesome icon for homepage | See icons below |
+| `weight` | Sort order in navigation | Number (lower = first) |
+
+## Common icons
+
+The homepage displays an icon for each workshop. Use [Font Awesome](https://fontawesome.com/icons) classes:
+
+| Icon | Class | Good for |
+|------|-------|----------|
+| {{< icon name="fab fa-python" >}} | `fab fa-python` | Python workshops |
+| {{< icon name="fab fa-html5" >}} | `fab fa-html5` | HTML/web workshops |
+| {{< icon name="fab fa-js" >}} | `fab fa-js` | JavaScript workshops |
+| {{< icon name="fas fa-laptop-code" >}} | `fas fa-laptop-code` | General coding |
+| {{< icon name="fas fa-microchip" >}} | `fas fa-microchip` | Hardware / Arduino |
+| {{< icon name="fas fa-shield-alt" >}} | `fas fa-shield-alt` | Security workshops |
+| {{< icon name="fas fa-database" >}} | `fas fa-database` | SQL / data workshops |
+| {{< icon name="fas fa-code" >}} | `fas fa-code` | General (default) |
+| {{< icon name="fas fa-gamepad" >}} | `fas fa-gamepad` | Game workshops |
+| {{< icon name="fas fa-music" >}} | `fas fa-music` | Music / audio |
+
+## Activity page fields
+
+Activity pages are simpler:
+
+```yaml
+---
+title: "Activity 1: Hello World"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 3
+---
+```
+
+## Answer key fields
+
+Answer keys should be hidden from navigation:
+
+```yaml
+---
+title: "Python: Basics - Answer Key"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 15
+hidden: true
+---
+```
+
+## The date field
+
+The `date` field is displayed on the site footer of each page. Update it whenever you make significant changes to a page so visitors know the content is current.
+
+Format: `YYYY-MM-DDTHH:MM:SS-07:00` (ISO 8601 with timezone) or `YYYY-MM-DD` (date only).
+
+## YAML tips
+
+- Always wrap string values in double quotes if they contain colons: `title: "Python: Basics"`
+- Boolean values don't need quotes: `draft: false`
+- Don't use tabs — YAML requires spaces for indentation
+- Frontmatter must be between `---` delimiters at the very top of the file

--- a/content/english/guidelines/translation-volunteer.md
+++ b/content/english/guidelines/translation-volunteer.md
@@ -1,0 +1,101 @@
+---
+title: "Translation volunteer guide"
+date: 2026-04-25T00:00:00-07:00
+draft: false
+weight: 6
+---
+
+Thank you for helping make workshops accessible to more kids around the world! This guide explains how to translate an existing workshop into a new language.
+
+## Before you start
+
+1. Check if the workshop already exists in your target language. Browse the `content/` directory for language folders:
+
+| Folder | Language |
+|--------|----------|
+| `content/english/` | English |
+| `content/espanol/` | Spanish |
+| `content/brazilian-portuguese/` | Brazilian Portuguese |
+| `content/korean/` | Korean |
+| `content/francais/` | French |
+| `content/german/` | German |
+| `content/simplified-chinese/` | Simplified Chinese |
+| `content/traditional-chinese/` | Traditional Chinese |
+| `content/kyrgyz/` | Kyrgyz |
+
+2. Open a [Translation Request issue](https://github.com/NuevoFoundation/workshops/issues/new?template=translation-request.yml) so others know you're working on it.
+
+## How translations work
+
+Each language has its own directory under `content/`. The folder structure inside each language mirrors the English version:
+
+```
+content/
+  english/
+    python-basics/
+      _index.md
+      basics/
+        writing-to-console.md
+      img/
+        screenshot.png
+  espanol/
+    python-basics/
+      _index.md
+      basics/
+        writing-to-console.md
+      img/
+        screenshot.png
+```
+
+## Step by step
+
+### 1. Copy the English workshop
+
+Copy the entire English workshop folder to your target language directory:
+
+```bash
+cp -r content/english/python-basics content/espanol/python-basics
+```
+
+### 2. Translate the content
+
+For each `.md` file:
+
+- **Translate** all visible text (titles, paragraphs, instructions, hints)
+- **Keep** all Hugo frontmatter keys in English (`title`, `date`, `draft`, `weight`, etc.)
+- **Translate** frontmatter values (`title: "Python: Conceptos basicos"`)
+- **Keep** all code examples in English (code is universal)
+- **Translate** code comments if they exist
+- **Keep** all file paths, image references, and Hugo shortcodes unchanged
+- **Translate** image alt text into the target language
+
+### 3. Handle images
+
+- **Shared images** (screenshots of code, diagrams): Copy the English `img/` or `media/` folder to your translation. Image files are the same across languages.
+- **Text-heavy images** (images containing English text): If possible, create localized versions. If not, keep the English version and note it in your PR.
+- **Alt text**: Always translate alt text to the target language. Screen readers use the page language setting.
+
+### 4. Test locally
+
+```bash
+hugo server -D
+```
+
+Navigate to your translated workshop and verify:
+- All pages load without errors
+- Images display correctly
+- Navigation works (TOC, next/previous)
+- Code examples are intact
+
+### 5. Submit your PR
+
+- Title: `Translation: [workshop-name] to [language]`
+- Description: List all files translated and any images that still contain English text
+- Make sure you translate the **entire workshop**, not just the landing page
+
+## Tips
+
+- Work through the workshop as a student would. If something doesn't make sense in translation, rephrase it.
+- Keep sentences short and clear. These workshops are for kids aged 8-18.
+- When in doubt about a technical term, keep the English term and add a brief explanation in the target language.
+- Don't translate workshop names in URLs or folder names — they must stay in English for Hugo routing.

--- a/content/english/guidelines/translation-volunteer.md
+++ b/content/english/guidelines/translation-volunteer.md
@@ -23,7 +23,7 @@ Thank you for helping make workshops accessible to more kids around the world! T
 | `content/traditional-chinese/` | Traditional Chinese |
 | `content/kyrgyz/` | Kyrgyz |
 
-2. Open a [Translation Request issue](https://github.com/NuevoFoundation/workshops/issues/new?template=translation-request.yml) so others know you're working on it.
+2. Open a [Translation Request issue](https://github.com/NuevoFoundation/workshops/issues/new) on GitHub so others know you're working on it.
 
 ## How translations work
 

--- a/content/english/guidelines/translation-volunteer.md
+++ b/content/english/guidelines/translation-volunteer.md
@@ -99,3 +99,11 @@ Navigate to your translated workshop and verify:
 - Keep sentences short and clear. These workshops are for kids aged 8-18.
 - When in doubt about a technical term, keep the English term and add a brief explanation in the target language.
 - Don't translate workshop names in URLs or folder names — they must stay in English for Hugo routing.
+
+## Language-specific notes
+
+### Spanish
+
+- Use **tú** verb conjugation for broad Latin American accessibility (not voseo)
+- Translate code comments but keep variable and function names in English
+- Technical terms like "string", "loop", "function" can stay in English with a brief Spanish explanation the first time they appear


### PR DESCRIPTION
## Summary

Adds 5 guideline pages that have been requested since July 2019, plus updates the guidelines landing page to link them.

## Changes

### New pages (5)
- **Translation volunteer guide** — Step-by-step for translating workshops, image handling, testing checklist (Closes #7)
- **Images and GIFs** — Sizing standards, alt text requirements, file naming, Hugo path resolution (Closes #10)
- **Navigation** — Frontmatter fields (weight, alwaysopen, hidden, draft), children shortcode, TOC behavior (Closes #11)
- **Code and interactivity** — Embedding Replit, Trinket, DotNetFiddle, CodePen; rawhtml shortcode; challenge structure (Closes #12)
- **Tags and metadata** — Complete frontmatter reference, required vs optional fields, icon list, YAML tips (Closes #13)

### Updated pages (1)
- **guidelines/_index.md** — Added links to all 5 new pages, new 'For translators' section, updated date

## Context
These 5 issues were opened by @thedanfernandez in July 2019 as placeholders for guideline content that was never written. After 5 sessions of deep workshop work (reviewing 42 workshops, fixing accessibility, standardizing TOC, creating answer keys, building a scaffold tool), we now have all the institutional knowledge to write definitive guidelines.

## Languages affected
English only — guidelines section is English-only

## Testing
- [ ] Hugo build passes
- [ ] All links in _index.md point to valid pages
- [ ] No broken shortcode syntax
- [ ] 10-model QA passed (3 clean passes)