### PR TITLE
Fix duplicate YAML keys in chatbot/_index.md

### DIFF
--- a/content/english/chatbot/_index.md
+++ b/content/english/chatbot/_index.md
@@ -10,9 +10,6 @@ icon: "fas fa-code"
 language: "no-code"
 topics: ["ai"]
 difficulties: ["beginner"]
-download: ""
-draft: false
-icon: "fas fa-code"
 ---
 
 ## Introduction


### PR DESCRIPTION
The frontmatter declared download, draft, and icon twice, causing Hugo v0.158+ to fail with: ''mapping key download already defined''. This blocked the entire site build (documented as a known issue in the repo README, lines 99-106). Removes the duplicate trailing block so hugo server and hugo --quiet --minify run cleanly.