### PR TITLE
Add Nuevo color palette guideline page and CSS variables

### DIFF
--- a/content/english/guidelines/colors.md
+++ b/content/english/guidelines/colors.md
@@ -1,0 +1,229 @@
+---
+title: "Nuevo color palette"
+date: 2026-06-11T00:00:00-07:00
+draft: false
+weight: 5
+icon: "fas fa-palette"
+---
+
+The Nuevo Foundation color palette keeps every workshop visually consistent with our brand. Use these colors anywhere you add visual styling — CSS demos, mini-games, embedded HTML, diagrams.
+
+## Official brand colors
+
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #36374d; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Emphasis</strong><br/>#36374d</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #00bed5; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Cyan</strong><br/>#00bed5</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #e13126; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Red</strong><br/>#e13126</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #e96469; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Coral</strong><br/>#e96469</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #fcb415; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Yellow</strong><br/>#fcb415</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #fbe6e0; height: 80px; border: 1px solid #e6e6e6;"></div>
+  <div style="padding: 0.75rem;"><strong>Blush</strong><br/>#fbe6e0</div>
+</div>
+
+</div>
+
+### Extended accent colors
+
+Designer-curated extras from our Canva system. Use for illustrations, badges, decorative accents, or whenever a workshop needs a wider color story than the core 6 brand colors.
+
+<div style="display: grid; grid-template-columns: repeat(auto-fill, 200px); gap: 1rem; margin: 1.5rem 0;">
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #78e08f; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Green</strong><br/>#78e08f</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #f19066; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Orange</strong><br/>#f19066</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #f7f1e3; height: 80px; border: 1px solid #e6e6e6;"></div>
+  <div style="padding: 0.75rem;"><strong>Cream</strong><br/>#f7f1e3</div>
+</div>
+
+</div>
+
+### Neutrals
+
+White, grays, and black for backgrounds, borders, body text, and shadows.
+
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #ffffff; height: 80px; border: 1px solid #e6e6e6;"></div>
+  <div style="padding: 0.75rem;"><strong>White</strong><br/>#ffffff</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #e6e6e6; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Gray 50</strong><br/>#e6e6e6</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #d3d2d2; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Gray 100</strong><br/>#d3d2d2</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #bcbdc1; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Gray 200</strong><br/>#bcbdc1</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #737474; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Gray 500</strong><br/>#737474</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #505150; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Gray 700</strong><br/>#505150</div>
+</div>
+
+<div style="border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-family: monospace;">
+  <div style="background: #231f20; height: 80px;"></div>
+  <div style="padding: 0.75rem;"><strong>Black</strong><br/>#231f20</div>
+</div>
+
+</div>
+
+## Full palette reference
+
+### Brand colors
+
+| Color | Hex | CSS variable | Common uses |
+|-------|-----|--------------|-------------|
+| Emphasis (dark) | `#36374d` | `--nuevo-emphasis` | Body text, headings, primary UI |
+| Cyan accent    | `#00bed5` | `--nuevo-cyan`     | Links, secondary highlights, info |
+| Red accent     | `#e13126` | `--nuevo-red`      | Primary buttons (dark stop), errors |
+| Coral accent   | `#e96469` | `--nuevo-coral`    | Primary buttons (light stop), warm highlights |
+| Yellow accent  | `#fcb415` | `--nuevo-yellow`   | Focus rings, callouts, badges |
+| Blush accent   | `#fbe6e0` | `--nuevo-blush`    | Page backgrounds, soft borders, subtle callouts |
+
+### Extended accent colors
+
+Designer-curated extras from our Canva system. Use for illustrations, badges, decorative accents, or whenever a workshop needs a wider color story than the core 6 brand colors.
+
+| Color | Hex | CSS variable | Common uses |
+|-------|-----|--------------|-------------|
+| Green   | `#78e08f` | `--nuevo-green`  | Success states, nature themes |
+| Orange  | `#f19066` | `--nuevo-orange` | Warm callouts, energy themes |
+| Cream   | `#f7f1e3` | `--nuevo-cream`  | Warm page backgrounds, paper textures |
+
+### Neutrals
+
+| Color | Hex | CSS variable |
+|-------|-----|--------------|
+| White            | `#ffffff` | `--nuevo-white` |
+| Gray 50          | `#e6e6e6` | `--nuevo-gray-50` |
+| Gray 100         | `#d3d2d2` | `--nuevo-gray-100` |
+| Gray 200         | `#bcbdc1` | `--nuevo-gray-200` |
+| Gray 500         | `#737474` | `--nuevo-gray-500` |
+| Gray 700         | `#505150` | `--nuevo-gray-700` |
+| Black            | `#231f20` | `--nuevo-black` |
+
+## How to use them
+
+### Option 1: CSS variables (recommended)
+
+The palette is exposed as CSS custom properties in `static/css/nuevo-palette.css`, which is automatically available on every workshop page.
+
+```css
+.my-button {
+  background: var(--nuevo-coral);
+  color: var(--nuevo-white);
+}
+
+.my-callout {
+  background: var(--nuevo-blush);
+  border-left: 4px solid var(--nuevo-coral);
+  color: var(--nuevo-emphasis);
+}
+```
+
+### Option 2: Hex values
+
+If you're writing standalone workshop code (e.g. files in `workshopcode/`) that students will open outside Hugo, paste the hex values directly:
+
+```css
+background: linear-gradient(135deg, #e96469, #e13126);
+```
+
+## Example: a Nuevo-themed button
+
+```css
+.pick-btn {
+  background: linear-gradient(135deg, var(--nuevo-coral), var(--nuevo-red));
+  color: var(--nuevo-white);
+  border: none;
+  border-radius: 999px;
+  padding: 1rem 2rem;
+  box-shadow: 0 8px 20px rgba(225, 49, 38, 0.35);
+}
+
+.pick-btn:focus-visible {
+  outline: 3px solid var(--nuevo-yellow);
+  outline-offset: 3px;
+}
+```
+
+See the [JavaScript: Korean Snack Picker Game](../../js-snack-picker/) workshop for a complete real-world example.
+
+## Accessibility & contrast
+
+Always check color contrast before shipping. The [WCAG 2.1 AA standard](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) requires:
+
+- **4.5:1** for normal text
+- **3:1** for large text (18pt+ or 14pt+ bold) and UI components
+
+### Verified combinations
+
+| Foreground | Background | Ratio | Verdict |
+|-----------|-----------|-------|---------|
+| `#36374d` Emphasis | `#ffffff` White | **12.5:1** ✅ | Use freely for body text |
+| `#36374d` Emphasis | `#fbe6e0` Blush | **10.2:1** ✅ | Use freely for body text |
+| `#ffffff` White | `#36374d` Emphasis | **12.5:1** ✅ | Use freely for body text |
+| `#ffffff` White | `#e13126` Red | **5.0:1** ✅ | Use for buttons, large text |
+| `#ffffff` White | `#e96469` Coral | **3.4:1** ⚠️ | Large text and UI only |
+| `#e13126` Red | `#ffffff` White | **5.0:1** ✅ | Use for links, large text |
+| `#00bed5` Cyan | `#ffffff` White | **2.3:1** ❌ | Decorative only, never body text |
+| `#fcb415` Yellow | `#36374d` Emphasis | **8.2:1** ✅ | Use for badges, focus rings |
+
+### Rules of thumb
+
+- **Body text** → always `#36374d` on a light background (white, blush, or pale gray)
+- **Buttons** → `#ffffff` on the coral-to-red gradient is safe
+- **Cyan** → use for decorative accents only (icons, focus rings, dividers), never body text on white
+- **Yellow** → great for focus rings and badges; pair with dark text on yellow, not yellow text on white
+
+When in doubt, run your combo through [WebAIM's Contrast Checker](https://webaim.org/resources/contrastchecker/).
+
+## Where this palette lives
+
+- **CSS variables:** `static/css/nuevo-palette.css` (loaded on every page)
+- **Reference page:** this file
+- **Quick reference in the new-workshop guide:** [Creating a new workshop, Nuevo Foundation color palette section](../new-workshops/#nuevo-foundation-color-palette)
+- **Real workshop using it:** [JavaScript: Korean Snack Picker Game](../../js-snack-picker/)

--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -29,3 +29,6 @@
 {{ if .IsHome }}
 <link href="{{ "css/workshop-explorer.css" | relURL }}" rel="stylesheet">
 {{ end }}
+
+<!-- Nuevo Foundation color palette (CSS variables, --nuevo-coral, etc.) -->
+<link href="{{ "css/nuevo-palette.css" | relURL }}" rel="stylesheet">

--- a/static/css/nuevo-palette.css
+++ b/static/css/nuevo-palette.css
@@ -1,0 +1,34 @@
+/* ============================================================
+   Nuevo Foundation color palette
+   ------------------------------------------------------------
+   Brand colors and neutrals exposed as CSS custom properties
+   so every workshop can use var(--nuevo-coral) instead of
+   typing hex codes (and getting them subtly wrong).
+
+   Full reference + accessibility/contrast notes:
+   https://workshops.nuevofoundation.org/guidelines/colors/
+   ============================================================ */
+
+:root {
+  /* Brand */
+  --nuevo-emphasis: #36374d;
+  --nuevo-cyan:     #00bed5;
+  --nuevo-red:      #e13126;
+  --nuevo-coral:    #e96469;
+  --nuevo-yellow:   #fcb415;
+  --nuevo-blush:    #fbe6e0;
+
+  /* Extended accent colors (designer's Canva system) */
+  --nuevo-green:  #78e08f;
+  --nuevo-orange: #f19066;
+  --nuevo-cream:  #f7f1e3;
+
+  /* Neutrals */
+  --nuevo-white:    #ffffff;
+  --nuevo-gray-50:  #e6e6e6;
+  --nuevo-gray-100: #d3d2d2;
+  --nuevo-gray-200: #bcbdc1;
+  --nuevo-gray-500: #737474;
+  --nuevo-gray-700: #505150;
+  --nuevo-black:    #231f20;
+}


### PR DESCRIPTION
Makes the Nuevo Foundation brand palette accessible to every contributor without guessing hex codes.

- content/english/guidelines/colors.md: new reference page with visual swatches, full hex/CSS-variable table, usage examples, and WCAG contrast verdicts for the most common combinations.
- static/css/nuevo-palette.css: 6 brand colors + 3 designer-extended accents (green, orange, cream) + 7 neutrals — all exposed as CSS custom properties (--nuevo-coral, --nuevo-emphasis, --nuevo-green, etc.)
 so workshops can use var(--nuevo-coral) instead of typing #e96469.
- layouts/partials/custom-head.html: loads the palette stylesheet on every page (no theme fork required, uses the existing extension point).

References the JS: Korean Snack Picker Game workshop as a real-world example of the palette in use. Complements PR #634 (palette table in the new-workshops guide) and PR #626 (CONTRIBUTING.md).